### PR TITLE
refactor: simplify generate_highlights (complexity 15 → ~3)

### DIFF
--- a/collector/highlights.py
+++ b/collector/highlights.py
@@ -20,6 +20,101 @@ class Highlight:
     timestamp: str
 
 
+def _categorize_error_event(event: TraceEvent) -> tuple[str | None, str | None]:
+    """Categorize ERROR events."""
+    return "error", "Error event"
+
+
+def _categorize_refusal_event(event: TraceEvent) -> tuple[str | None, str | None]:
+    """Categorize REFUSAL and POLICY_VIOLATION events."""
+    if event.event_type == EventType.POLICY_VIOLATION:
+        return "refusal", "Policy violation"
+    return "refusal", "Refusal triggered"
+
+
+def _categorize_behavior_alert(event: TraceEvent) -> tuple[str | None, str | None]:
+    """Categorize BEHAVIOR_ALERT events."""
+    return "anomaly", str(event.data.get("signal", "Behavior anomaly"))
+
+
+def _categorize_safety_check(event: TraceEvent) -> tuple[str | None, str | None]:
+    """Categorize SAFETY_CHECK events."""
+    outcome = event.data.get("outcome", "pass")
+    if outcome != "pass":
+        return "anomaly", f"Safety check {outcome}"
+    return None, None
+
+
+def _categorize_decision_event(event: TraceEvent, composite: float) -> tuple[str | None, str | None]:
+    """Categorize DECISION events."""
+    confidence = event.data.get("confidence", 0.5)
+    if confidence < 0.5:
+        return "decision", f"Low confidence decision ({confidence:.2f})"
+    if composite > 0.6:
+        return "decision", "High-impact decision"
+    return None, None
+
+
+def _categorize_tool_result(event: TraceEvent, severity: float) -> tuple[str | None, str | None]:
+    """Categorize TOOL_RESULT events."""
+    if event.data.get("error"):
+        return "error", "Tool execution failed"
+    if severity > 0.7:
+        return "anomaly", "Unusual tool result"
+    return None, None
+
+
+def _get_event_categorization(
+    event: TraceEvent,
+    composite: float,
+    severity: float,
+) -> tuple[str | None, str | None]:
+    """Determine highlight type and reason for an event.
+
+    Returns:
+        Tuple of (highlight_type, reason) or (None, None) if not highlight-worthy
+    """
+    categorizer = {
+        EventType.ERROR: lambda e: _categorize_error_event(e),
+        EventType.REFUSAL: lambda e: _categorize_refusal_event(e),
+        EventType.POLICY_VIOLATION: lambda e: _categorize_refusal_event(e),
+        EventType.BEHAVIOR_ALERT: lambda e: _categorize_behavior_alert(e),
+        EventType.SAFETY_CHECK: lambda e: _categorize_safety_check(e),
+        EventType.DECISION: lambda e: _categorize_decision_event(e, composite),
+        EventType.TOOL_RESULT: lambda e: _categorize_tool_result(e, severity),
+    }
+
+    handler = categorizer.get(event.event_type)
+    if handler:
+        return handler(event)
+    return None, None
+
+
+def _calculate_importance(severity: float, composite: float) -> float:
+    """Calculate importance score from severity and composite rankings."""
+    return min(severity, composite) if composite > 0 else severity
+
+
+def _build_highlight_dict(
+    event: TraceEvent,
+    highlight_type: str,
+    reason: str,
+    importance: float,
+    event_headline_fn: Any,
+) -> dict[str, Any]:
+    """Build a highlight dictionary from event data."""
+    timestamp = event.timestamp.isoformat() if hasattr(event.timestamp, "isoformat") else str(event.timestamp)
+    return {
+        "event_id": event.id,
+        "event_type": str(event.event_type),
+        "highlight_type": highlight_type,
+        "importance": round(importance, 4),
+        "reason": reason,
+        "timestamp": timestamp,
+        "headline": event_headline_fn(event),
+    }
+
+
 def generate_highlights(
     events: list[TraceEvent],
     rankings: list[dict[str, Any]],
@@ -36,8 +131,6 @@ def generate_highlights(
         List of highlight dicts sorted by importance, limited to 20
     """
     highlights: list[dict[str, Any]] = []
-
-    # Build ranking lookup
     ranking_by_id = {r["event_id"]: r for r in rankings}
 
     for event in events:
@@ -45,59 +138,12 @@ def generate_highlights(
         composite = ranking.get("composite", 0)
         severity = ranking.get("severity", 0)
 
-        highlight_type: str | None = None
-        reason: str | None = None
+        highlight_type, reason = _get_event_categorization(event, composite, severity)
 
-        # Determine highlight type and reason
-        if event.event_type == EventType.ERROR:
-            highlight_type = "error"
-            reason = "Error event"
-        elif event.event_type == EventType.REFUSAL:
-            highlight_type = "refusal"
-            reason = "Refusal triggered"
-        elif event.event_type == EventType.POLICY_VIOLATION:
-            highlight_type = "refusal"
-            reason = "Policy violation"
-        elif event.event_type == EventType.BEHAVIOR_ALERT:
-            highlight_type = "anomaly"
-            reason = str(event.data.get("signal", "Behavior anomaly"))
-        elif event.event_type == EventType.SAFETY_CHECK:
-            outcome = event.data.get("outcome", "pass")
-            if outcome != "pass":
-                highlight_type = "anomaly"
-                reason = f"Safety check {outcome}"
-        elif event.event_type == EventType.DECISION:
-            confidence = event.data.get("confidence", 0.5)
-            if confidence < 0.5:
-                highlight_type = "decision"
-                reason = f"Low confidence decision ({confidence:.2f})"
-            elif composite > 0.6:
-                highlight_type = "decision"
-                reason = "High-impact decision"
-        elif event.event_type == EventType.TOOL_RESULT:
-            if event.data.get("error"):
-                highlight_type = "error"
-                reason = "Tool execution failed"
-            elif severity > 0.7:
-                highlight_type = "anomaly"
-                reason = "Unusual tool result"
-
-        # Only add if we have a highlight type and sufficient importance
         if highlight_type and (severity > 0.5 or composite > 0.5):
-            importance = min(severity, composite) if composite > 0 else severity
-            timestamp = event.timestamp.isoformat() if hasattr(event.timestamp, "isoformat") else str(event.timestamp)
-            highlights.append(
-                {
-                    "event_id": event.id,
-                    "event_type": str(event.event_type),
-                    "highlight_type": highlight_type,
-                    "importance": round(importance, 4),
-                    "reason": reason,
-                    "timestamp": timestamp,
-                    "headline": event_headline_fn(event),
-                }
-            )
+            importance = _calculate_importance(severity, composite)
+            highlight = _build_highlight_dict(event, highlight_type, reason, importance, event_headline_fn)
+            highlights.append(highlight)
 
-    # Sort by importance, limit to top 20
     highlights.sort(key=lambda h: -h["importance"])
     return highlights[:20]


### PR DESCRIPTION
## Summary

- Extracts per-event-type categorization into dedicated helpers (`_categorize_error_event`, `_categorize_refusal_event`, `_categorize_behavior_alert`, `_categorize_safety_check`, `_categorize_decision_event`, `_categorize_tool_result`)
- Adds `_get_event_categorization` dispatch table replacing a 40-line if/elif chain
- Extracts `_calculate_importance` and `_build_highlight_dict` to separate highlight assembly from classification logic
- `generate_highlights` itself is now ~15 lines with cyclomatic complexity ~3 (was 15)

No behavior changes — all existing tests pass.

Closes #16

## Test plan

- [x] `ruff check .` — all checks passed
- [x] `python3 -m pytest -q` — 1053 passed, 96 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)