### PR TITLE
Fix #24: Implement fix note endpoint

### DIFF
--- a/api/schemas.py
+++ b/api/schemas.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from agent_debugger_sdk.core.events import EventType, RiskLevel, SafetyOutcome, SessionStatus
 
@@ -280,3 +280,16 @@ class CheckpointDeltaSchema(BaseModel):
     importance_delta: float
     restore_value: float
     state_keys_changed: list[str]
+
+
+class FixNoteRequest(BaseModel):
+    """Request schema for adding/updating a fix note."""
+
+    note: str = Field(min_length=1, max_length=2000)
+
+
+class FixNoteResponse(BaseModel):
+    """Response schema for fix note operations."""
+
+    session_id: str
+    fix_note: str

--- a/api/session_routes.py
+++ b/api/session_routes.py
@@ -12,6 +12,8 @@ from api.schemas import (
     CheckpointListResponse,
     DecisionTreeResponse,
     DeleteResponse,
+    FixNoteRequest,
+    FixNoteResponse,
     SessionDetailResponse,
     SessionListResponse,
     SessionUpdateRequest,
@@ -163,3 +165,16 @@ async def export_session(
         content=export_data,
         headers={"Content-Disposition": f'attachment; filename="session_{session_id}_export.json"'},
     )
+
+
+@router.post("/api/sessions/{session_id}/fix-note", response_model=FixNoteResponse)
+async def add_fix_note(
+    session_id: str,
+    request: FixNoteRequest,
+    repo: TraceRepository = Depends(get_repository),
+) -> FixNoteResponse:
+    await require_session(repo, session_id)
+    updated_session = await repo.add_fix_note(session_id, request.note)
+    if updated_session:
+        await repo.commit()
+    return FixNoteResponse(session_id=session_id, fix_note=request.note)


### PR DESCRIPTION
## Summary
Implements the missing `POST /api/sessions/{id}/fix-note` endpoint that the frontend expects.

## Changes
- Added `FixNoteRequest` and `FixNoteResponse` schemas to `api/schemas.py`
- Added `POST /api/sessions/{session_id}/fix-note` route to `api/session_routes.py`
- Added validation constraints: `min_length=1` and `max_length=2000` for fix notes
- Uses existing `repo.add_fix_note()` storage method

## Testing
- Ruff checks pass
- All existing tests pass, including:
  - `test_fix_note_empty_body` - validates empty string rejection
  - `test_fix_note_too_long` - validates max length enforcement
  - `test_fix_note_update_via_api` - validates end-to-end functionality

## Acceptance Criteria
✅ `POST /api/sessions/{id}/fix-note` returns 200 with saved note
✅ Frontend `addFixNote()` works end-to-end
✅ Ruff and existing tests pass

Closes #24