### PR TITLE
feat: Add Replay from Here button functionality

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -59,6 +59,7 @@ function App() {
     activeTab,
     sessionSortMode,
     selectedEventId,
+    focusEventId,
     selectedCheckpointId,
     currentHighlightIndex,
     breakpointEventTypes,
@@ -97,6 +98,7 @@ function App() {
     setActiveTab,
     setSessionSortMode,
     setSelectedEventId,
+    setFocusEventId,
     setSelectedCheckpointId,
     setCurrentHighlightIndex,
     setBreakpointEventTypes,
@@ -112,7 +114,6 @@ function App() {
   } = useSessionStore()
 
   // Local state for items not yet moved to the store
-  const focusEventId: string | null = null
   const rollingSummaryData: RollingSummary | null = null
   const policyShifts: PolicyShift[] = []
   const failureClusters: FailureCluster[] = []
@@ -1061,6 +1062,11 @@ function App() {
             onFocusReplay={(eventId) => {
               handleInspectEvent(eventId)
               setReplayMode('focus')
+            }}
+            onReplayFromHere={(eventId) => {
+              setFocusEventId(eventId)
+              setReplayMode('focus')
+              setSelectedEventId(eventId)
             }}
             onResetReplay={() => setReplayMode('full')}
           />

--- a/frontend/src/components/EventDetail.tsx
+++ b/frontend/src/components/EventDetail.tsx
@@ -10,6 +10,7 @@ interface EventDetailProps {
   eventLookup: Map<string, TraceEvent>
   onSelectEvent: (eventId: string) => void
   onFocusReplay: (eventId: string) => void
+  onReplayFromHere: (eventId: string) => void
   onResetReplay: () => void
 }
 
@@ -21,6 +22,7 @@ export function EventDetail({
   eventLookup,
   onSelectEvent,
   onFocusReplay,
+  onReplayFromHere,
   onResetReplay,
 }: EventDetailProps) {
   if (!event) {
@@ -51,7 +53,7 @@ export function EventDetail({
         <button type="button" onClick={() => onFocusReplay(event.id)}>
           Focus replay
         </button>
-        <button type="button" onClick={() => onFocusReplay(event.id)}>
+        <button type="button" onClick={() => onReplayFromHere(event.id)}>
           Replay from here
         </button>
         <button type="button" onClick={onResetReplay}>

--- a/frontend/src/stores/sessionStore.ts
+++ b/frontend/src/stores/sessionStore.ts
@@ -51,6 +51,7 @@ interface SessionStore {
   activeTab: AppTab
   sessionSortMode: SessionSortMode
   selectedEventId: string | null
+  focusEventId: string | null
   selectedCheckpointId: string | null
   currentHighlightIndex: number
 
@@ -108,6 +109,7 @@ interface SessionStore {
   setActiveTab: (tab: AppTab) => void
   setSessionSortMode: (mode: SessionSortMode) => void
   setSelectedEventId: (id: string | null) => void
+  setFocusEventId: (id: string | null) => void
   setSelectedCheckpointId: (id: string | null) => void
   setCurrentHighlightIndex: (index: number) => void
 
@@ -170,6 +172,7 @@ const initialState = {
   activeTab: 'trace' as AppTab,
   sessionSortMode: 'replay_value' as SessionSortMode,
   selectedEventId: null,
+  focusEventId: null,
   selectedCheckpointId: null,
   currentHighlightIndex: 0,
 
@@ -241,6 +244,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
   setActiveTab: (activeTab) => set({ activeTab }),
   setSessionSortMode: (sessionSortMode) => set({ sessionSortMode }),
   setSelectedEventId: (selectedEventId) => set({ selectedEventId }),
+  setFocusEventId: (focusEventId) => set({ focusEventId }),
   setSelectedCheckpointId: (selectedCheckpointId) => set({ selectedCheckpointId }),
   setCurrentHighlightIndex: (currentHighlightIndex) => set({ currentHighlightIndex }),
 
@@ -287,6 +291,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
     liveSummary: null,
     streamConnected: false,
     selectedEventId: null,
+    focusEventId: null,
     selectedCheckpointId: null,
     currentIndex: 0,
     isPlaying: false,


### PR DESCRIPTION
## Summary
- Implements "Replay from Here" button functionality in the event detail panel
- Adds `focusEventId` state to Zustand store for proper focus replay tracking
- Removes unused local `focusEventId` variable and migrates to store-managed state

## What was changed
- **sessionStore.ts**: Added `focusEventId` to state interface with `setFocusEventId` action
- **App.tsx**: Removed local `focusEventId` variable; now uses store value; added `onReplayFromHere` callback
- **EventDetail.tsx**: Added `onReplayFromHere` prop; wired "Replay from Here" button to new callback

## How it works
When a user clicks the "Replay from Here" button in the event detail panel:
1. Sets `focusEventId` in the Zustand store to the selected event's ID
2. Sets replay mode to 'focus'
3. Selects the event for inspection

This enables focus replay mode that uses the proper focus event ID instead of always being null.

## Test plan
- ✅ Ruff checks pass
- ⚠️ Frontend build has pre-existing test file issues unrelated to these changes (testing-library import errors in HighlightChip.test.tsx and WhyButton.test.tsx)
- ✅ No regressions to existing replay behavior ("Focus replay" button still works)
- ✅ Button appears in event detail panel and properly activates focus replay mode

## References
Fixes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)