### PR TITLE
fix: narrow broad exception catching in transport.py (#38)

### DIFF
--- a/agent_debugger_sdk/transport.py
+++ b/agent_debugger_sdk/transport.py
@@ -254,7 +254,7 @@ class HttpTransport:
             try:
                 await self._execute_request(method=method, path=path, payload=payload)
                 return
-            except Exception as exc:
+            except (httpx.TimeoutException, httpx.NetworkError, TransientError, PermanentError, ValueError) as exc:
                 last_error, should_retry = self._classify_error(exc)
 
                 if not should_retry:


### PR DESCRIPTION
## Summary
Replaces bare \`except Exception:\` with specific exception types in HTTP retry logic for better error handling.

## Changes
- **Line 257**: Changed from \`except Exception:\` to specific exception types:
  - \`httpx.TimeoutException\` - network timeouts
  - \`httpx.NetworkError\` - connection failures
  - \`TransientError\` - server errors (5xx)
  - \`PermanentError\` - client errors (4xx)
  - \`ValueError\` - unsupported HTTP method

## Acceptance Criteria
✓ No bare \`except Exception:\` in retry logic where specific type works
✓ Retry behavior remains intact via \`_classify_error()\` method
✓ Proper error logging maintained for both transient and permanent errors

## Context
Addresses issue #38 - debt scan found broad exception catching that should be replaced with specific network/timeout error types while maintaining retry behavior.

Closes #38

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>