### PR TITLE
fix: remove module-level skip markers from feature test files

### DIFF
--- a/tests/test_feature_2_failure_memory.py
+++ b/tests/test_feature_2_failure_memory.py
@@ -16,8 +16,7 @@ import pytest
 
 from agent_debugger_sdk.core.events import EventType, TraceEvent
 
-# Skip all tests in this module - feature not yet implemented
-pytestmark = pytest.mark.skip(reason="Feature 2 (failure_memory) not yet implemented")
+# Note: Feature 2 (failure_memory) tests are implemented but feature module may not exist yet
 
 
 # =============================================================================

--- a/tests/test_feature_4_behavior_alerts.py
+++ b/tests/test_feature_4_behavior_alerts.py
@@ -11,8 +11,7 @@ from typing import Any
 
 import pytest
 
-# Skip all tests in this module - feature not yet implemented
-pytestmark = pytest.mark.skip(reason="Feature 4 (behavior_monitor) not yet implemented")
+# Note: Feature 4 (behavior_monitor) tests are implemented but feature module may not exist yet
 
 
 # Define BehaviorChange dataclass as specified

--- a/tests/test_feature_5_nl_debugging.py
+++ b/tests/test_feature_5_nl_debugging.py
@@ -6,8 +6,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-# Skip all tests in this module - feature not yet implemented
-pytestmark = pytest.mark.skip(reason="Feature 5 (nl_debugging) not yet implemented")
+# Note: Feature 5 (nl_debugging) tests are implemented but feature module may not exist yet
 
 
 # Dataclasses for test structures


### PR DESCRIPTION
## Summary
- Removes `pytestmark = pytest.mark.skip()` from three feature test files
- These files already have comprehensive test implementations (happy path, edge cases, error handling)
- The skip markers were preventing all tests from running despite complete test suites

## Changes
- `tests/test_feature_2_failure_memory.py` - Removed skip marker for FailureMemory tests
- `tests/test_feature_4_behavior_alerts.py` - Removed skip marker for BehaviorMonitor tests
- `tests/test_feature_5_nl_debugging.py` - Removed skip marker for NaturalLanguageDebugger tests

## Notes
The feature modules themselves may not exist yet, which will cause import errors when tests run. However, removing the skip markers allows the existing test implementations to be validated rather than silently skipped.

## Test plan
- [x] Ruff checks pass for modified files
- [ ] Full pytest run (module import failures expected until feature modules are implemented)

Fixes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)