### PR TITLE
fix: add accessibility labels to frontend controls

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -712,24 +712,41 @@ function App() {
               )}
             </div>
             <div className="breakpoint-grid">
-              <label>
+              <label htmlFor="breakpoint-events">
                 Event breakpoints
-                <input value={breakpointEventTypes} onChange={(event) => setBreakpointEventTypes(event.target.value)} />
-              </label>
-              <label>
-                Tool breakpoints
-                <input value={breakpointToolNames} onChange={(event) => setBreakpointToolNames(event.target.value)} />
-              </label>
-              <label>
-                Confidence floor
-                <input value={breakpointConfidenceBelow} onChange={(event) => setBreakpointConfidenceBelow(event.target.value)} />
-              </label>
-              <label>
-                Safety outcomes
-                <input value={breakpointSafetyOutcomes} onChange={(event) => setBreakpointSafetyOutcomes(event.target.value)} />
-              </label>
-              <label className="checkbox-label">
                 <input
+                  id="breakpoint-events"
+                  value={breakpointEventTypes}
+                  onChange={(event) => setBreakpointEventTypes(event.target.value)}
+                />
+              </label>
+              <label htmlFor="breakpoint-tools">
+                Tool breakpoints
+                <input
+                  id="breakpoint-tools"
+                  value={breakpointToolNames}
+                  onChange={(event) => setBreakpointToolNames(event.target.value)}
+                />
+              </label>
+              <label htmlFor="breakpoint-confidence">
+                Confidence floor
+                <input
+                  id="breakpoint-confidence"
+                  value={breakpointConfidenceBelow}
+                  onChange={(event) => setBreakpointConfidenceBelow(event.target.value)}
+                />
+              </label>
+              <label htmlFor="breakpoint-safety">
+                Safety outcomes
+                <input
+                  id="breakpoint-safety"
+                  value={breakpointSafetyOutcomes}
+                  onChange={(event) => setBreakpointSafetyOutcomes(event.target.value)}
+                />
+              </label>
+              <label className="checkbox-label" htmlFor="stop-at-breakpoint">
+                <input
+                  id="stop-at-breakpoint"
                   type="checkbox"
                   checked={stopAtBreakpoint}
                   onChange={(event) => setStopAtBreakpoint(event.target.checked)}

--- a/frontend/src/components/DecisionTree.tsx
+++ b/frontend/src/components/DecisionTree.tsx
@@ -298,24 +298,24 @@ export function DecisionTree({ tree, selectedEventId, onSelectEvent }: DecisionT
         </button>
         <span className="zoom-level">{Math.round(zoom * 100)}%</span>
       </div>
-      <div className="tree-legend">
-        <span className="legend-item">
+      <div className="tree-legend" role="legend" aria-label="Decision tree legend">
+        <span className="legend-item" aria-label="Session nodes: agent start and end events">
           <span className="legend-dot" style={{ backgroundColor: NODE_COLORS.agent_start }} />
           Session
         </span>
-        <span className="legend-item">
+        <span className="legend-item" aria-label="LLM nodes: large language model requests and responses">
           <span className="legend-dot" style={{ backgroundColor: NODE_COLORS.llm_request }} />
           LLM
         </span>
-        <span className="legend-item">
+        <span className="legend-item" aria-label="Tool nodes: tool calls and results">
           <span className="legend-dot" style={{ backgroundColor: NODE_COLORS.tool_call }} />
           Tool
         </span>
-        <span className="legend-item">
+        <span className="legend-item" aria-label="Decision nodes: agent decision points">
           <span className="legend-dot" style={{ backgroundColor: NODE_COLORS.decision }} />
           Decision
         </span>
-        <span className="legend-item">
+        <span className="legend-item" aria-label="Risk nodes: errors and policy violations">
           <span className="legend-dot" style={{ backgroundColor: NODE_COLORS.error }} />
           Risk
         </span>

--- a/frontend/src/components/FixAnnotation.tsx
+++ b/frontend/src/components/FixAnnotation.tsx
@@ -50,7 +50,7 @@ export default function FixAnnotation({ sessionId, existingNote }: FixAnnotation
       <div className="fix-annotation">
         <span className="fix-label">Fix:</span>
         <span className="fix-text">{savedNote}</span>
-        <button className="fix-edit-btn" onClick={() => setIsEditing(true)}>Edit</button>
+        <button className="fix-edit-btn" onClick={() => setIsEditing(true)} aria-label="Edit fix note">Edit</button>
       </div>
     )
   }


### PR DESCRIPTION
## Summary

This PR fixes accessibility issues identified in #45 by adding proper accessibility attributes to interactive elements throughout the frontend.

## Changes

### FixAnnotation.tsx
- Added `aria-label="Edit fix note"` to the Edit button for screen reader clarity

### App.tsx  
- Added `htmlFor` and `id` attributes to all breakpoint configuration inputs:
  - Event breakpoints (`id="breakpoint-events"`)
  - Tool breakpoints (`id="breakpoint-tools"`)
  - Confidence floor (`id="breakpoint-confidence"`)
  - Safety outcomes (`id="breakpoint-safety"`)
  - Stop at breakpoint checkbox (`id="stop-at-breakpoint"`)
- This ensures proper label-input associations for assistive technologies

### DecisionTree.tsx
- Added `role="legend"` and `aria-label` to the legend container
- Added descriptive `aria-label` attributes to each legend item:
  - "Session nodes: agent start and end events"
  - "LLM nodes: large language model requests and responses"
  - "Tool nodes: tool calls and results"
  - "Decision nodes: agent decision points"
  - "Risk nodes: errors and policy violations"

## Validation

- ✅ Frontend build passes (`npm run build` with vite)
- ✅ All changes follow existing accessibility patterns in the codebase
- ✅ No visual regressions (only semantic HTML changes)

## Acceptance Criteria

- [x] All interactive elements have accessible labels
- [x] Frontend build passes
- [x] No visual regressions

Closes #45