### PR TITLE
fix: add pytest skip markers for pydantic_ai tests when package not installed

### DIFF
--- a/agent_debugger_sdk/adapters/tests/test_bug_fixes.py
+++ b/agent_debugger_sdk/adapters/tests/test_bug_fixes.py
@@ -83,6 +83,10 @@ class TestBUG002DuplicateEvents:
     """Test that events are not duplicated in buffer after fix."""
 
     @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        not __import__("agent_debugger_sdk.adapters.pydantic_ai", fromlist=["PYDANTIC_AI_AVAILABLE"]).PYDANTIC_AI_AVAILABLE,
+        reason="pydantic_ai is not installed"
+    )
     async def test_pydantic_ai_no_duplicates(self):
         """Test that PydanticAI adapter doesn't publish duplicate events."""
         buffer = get_event_buffer()

--- a/agent_debugger_sdk/adapters/tests/test_pydantic_ai.py
+++ b/agent_debugger_sdk/adapters/tests/test_pydantic_ai.py
@@ -11,8 +11,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from agent_debugger_sdk.adapters.pydantic_ai import PYDANTIC_AI_AVAILABLE
 from agent_debugger_sdk.core.events import EventType
 from collector.buffer import get_event_buffer
+
+# Skip all tests in this module if pydantic_ai is not installed
+pytestmark = pytest.mark.skipif(
+    not PYDANTIC_AI_AVAILABLE,
+    reason="pydantic_ai is not installed"
+)
 
 
 class MockAgent:


### PR DESCRIPTION
## Summary
Fixes #64 - PydanticAI adapter tests failing in CI with ImportError

## Problem
All PRs since the adapter refactoring (PR #30) showed 27 test failures in CI — every single one was `ImportError: PydanticAI is not installed`. The tests were properly skipped before the refactoring, but the new `pydantic_ai/` package structure broke the import detection.

## Solution
Added module-level pytest skip markers to prevent test collection when `pydantic_ai` is not installed:

1. **test_pydantic_ai.py**: Added `pytestmark` to skip entire module
2. **test_bug_fixes.py**: Added `@pytest.mark.skipif` decorator to `test_pydantic_ai_no_duplicates`

Both check `PYDANTIC_AI_AVAILABLE` flag and skip with clear reason message.

## Testing
- ✅ `ruff check .` passes
- ✅ Tests now properly skip when pydantic_ai not installed
- ✅ No behavior changes when pydantic_ai IS installed
- ✅ CI will pass with 0 test failures

## Files Changed
- `agent_debugger_sdk/adapters/tests/test_pydantic_ai.py` - Added module-level skip marker
- `agent_debugger_sdk/adapters/tests/test_bug_fixes.py` - Added skip marker to pydantic_ai test

🤖 Generated with [Claude Code](https://claude.com/claude-code)