### PR TITLE
fix: HttpTransport catches all exceptions, preventing ConnectionError from breaking agent execution

### DIFF
--- a/agent_debugger_sdk/transport.py
+++ b/agent_debugger_sdk/transport.py
@@ -254,7 +254,7 @@ class HttpTransport:
             try:
                 await self._execute_request(method=method, path=path, payload=payload)
                 return
-            except (httpx.TimeoutException, httpx.NetworkError, TransientError, PermanentError, ValueError) as exc:
+            except Exception as exc:
                 last_error, should_retry = self._classify_error(exc)
 
                 if not should_retry:


### PR DESCRIPTION
## Summary

- `HttpTransport._send_with_retry` had a narrow `except` clause that only caught specific httpx/Transport exception types
- Python's built-in `ConnectionError` (an `OSError` subclass) was not in the list and propagated to callers, breaking agent execution
- Broadened the clause to `except Exception` so all errors route through the existing `_classify_error` fallback, which treats unknown errors as `PermanentError` and swallows them with a log warning

## Test plan

- [ ] `tests/test_sdk_transport.py::test_transport_graceful_on_failure` — was FAILED, now passes
- [ ] `tests/test_sdk_transport.py::test_transport_send_session_start_graceful_on_failure` — was FAILED, now passes
- [ ] `tests/test_sdk_transport.py::test_transport_send_session_update_graceful_on_failure` — was FAILED, now passes
- [ ] All 10 transport tests pass: `python3 -m pytest tests/test_sdk_transport.py -q`
- [ ] `ruff check agent_debugger_sdk/transport.py` — clean

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)