### PR TITLE
fix: HttpTransport does not catch built-in ConnectionError, leaking exceptions to callers

### DIFF
--- a/agent_debugger_sdk/transport.py
+++ b/agent_debugger_sdk/transport.py
@@ -254,7 +254,7 @@ class HttpTransport:
             try:
                 await self._execute_request(method=method, path=path, payload=payload)
                 return
-            except (httpx.TimeoutException, httpx.NetworkError, TransientError, PermanentError, ValueError) as exc:
+            except Exception as exc:
                 last_error, should_retry = self._classify_error(exc)
 
                 if not should_retry:


### PR DESCRIPTION
## Summary
- Fixed `HttpTransport._send_with_retry` to catch all exceptions, not just a specific list
- Built-in exceptions like `ConnectionError` are now properly caught and handled by the existing `_classify_error` fallback logic
- This prevents unexpected exceptions from breaking agent execution

## Changes
- Modified exception clause in `agent_debugger_sdk/transport.py:257` from catching specific exception types to catching `Exception`
- The existing `_classify_error` method already handles unknown exceptions as permanent errors, so this is a safe broadening

## Test Impact
This fixes the following failing tests:
- `test_transport_graceful_on_failure`
- `test_transport_send_session_start_graceful_on_failure`
- `test_transport_send_session_update_graceful_on_failure`

All three tests simulate `ConnectionError` being raised from the HTTP client and expect the transport to handle it gracefully without propagating the exception.

Fixes #98

## Test plan
- [x] Code review: Exception handling logic verified
- [x] Linting: `ruff check` passes
- [ ] Tests: Need pytest in worktree environment to run

🤖 Generated with [Claude Code](https://claude.com/claude-code)