### PR TITLE
fix: catch OSError in HttpTransport to handle built-in ConnectionError

### DIFF
--- a/agent_debugger_sdk/transport.py
+++ b/agent_debugger_sdk/transport.py
@@ -222,6 +222,8 @@ class HttpTransport:
             return TransientError(f"Request timeout: {exc}"), True
         if isinstance(exc, httpx.NetworkError):
             return TransientError(f"Network error: {exc}"), True
+        if isinstance(exc, OSError):
+            return TransientError(f"OS-level connection error: {exc}"), True
         if isinstance(exc, TransientError):
             return exc, True
         if isinstance(exc, PermanentError):
@@ -254,7 +256,14 @@ class HttpTransport:
             try:
                 await self._execute_request(method=method, path=path, payload=payload)
                 return
-            except (httpx.TimeoutException, httpx.NetworkError, TransientError, PermanentError, ValueError) as exc:
+            except (
+                httpx.TimeoutException,
+                httpx.NetworkError,
+                OSError,
+                TransientError,
+                PermanentError,
+                ValueError,
+            ) as exc:
                 last_error, should_retry = self._classify_error(exc)
 
                 if not should_retry:

--- a/collector/intelligence/__init__.py
+++ b/collector/intelligence/__init__.py
@@ -5,7 +5,8 @@ The main entry point is the :class:`TraceIntelligence` class.
 """
 
 from .facade import TraceIntelligence
-from .helpers import event_value as _event_value, mean as _mean
+from .helpers import event_value as _event_value
+from .helpers import mean as _mean
 
 __all__ = [
     "TraceIntelligence",

--- a/collector/intelligence/compute.py
+++ b/collector/intelligence/compute.py
@@ -7,8 +7,8 @@ from typing import Any
 
 from agent_debugger_sdk.core.events import Checkpoint, EventType, TraceEvent
 
-from .helpers import event_value
 from .event_utils import retention_tier
+from .helpers import event_value
 
 
 def compute_event_ranking(

--- a/collector/intelligence/facade.py
+++ b/collector/intelligence/facade.py
@@ -15,7 +15,8 @@ from ..highlights import generate_highlights
 from ..live_monitor import LiveMonitor
 from ..ranking import CheckpointRankingService, EventRankingService
 from .compute import compute_checkpoint_rankings, compute_event_ranking, detect_tool_loop
-from .event_utils import event_headline, fingerprint as fingerprint_fn, retention_tier
+from .event_utils import event_headline, retention_tier
+from .event_utils import fingerprint as fingerprint_fn
 from .helpers import event_value, mean
 
 


### PR DESCRIPTION
## Summary

- **Bug fix**: `HttpTransport._send_with_retry` now catches `OSError` (which covers Python's built-in `ConnectionError`, `BrokenPipeError`, etc.) in addition to httpx-specific exceptions, preventing unhandled exceptions from crashing agent execution
- **Lint fix**: 3 ruff `I001` (unsorted imports) errors in `collector/intelligence/` auto-fixed

## Root Cause

The `except` tuple in `_send_with_retry` only listed httpx exception types. Python's built-in `ConnectionError` (a subclass of `OSError`) escaped uncaught when an OS-level network failure occurred. `OSError` is now classified as a transient error and retried with exponential backoff.

## Files Changed

- `agent_debugger_sdk/transport.py` — add `OSError` to except clause and `_classify_error`
- `collector/intelligence/__init__.py` — fix import sort order
- `collector/intelligence/compute.py` — fix import sort order
- `collector/intelligence/facade.py` — fix import sort order

## Test plan

- [x] `ruff check .` — all checks passed
- [x] `pytest tests/test_sdk_transport.py` — 10 passed (previously 3 failing)
- [x] No regressions in other transport tests

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)