### PR TITLE
fix: handle OSError in transport retry logic

### DIFF
--- a/agent_debugger_sdk/transport.py
+++ b/agent_debugger_sdk/transport.py
@@ -222,6 +222,9 @@ class HttpTransport:
             return TransientError(f"Request timeout: {exc}"), True
         if isinstance(exc, httpx.NetworkError):
             return TransientError(f"Network error: {exc}"), True
+        if isinstance(exc, OSError):
+            # Covers ConnectionError, BrokenPipeError, etc. - OS-level connection issues
+            return TransientError(f"OS-level connection error: {exc}"), True
         if isinstance(exc, TransientError):
             return exc, True
         if isinstance(exc, PermanentError):
@@ -254,7 +257,7 @@ class HttpTransport:
             try:
                 await self._execute_request(method=method, path=path, payload=payload)
                 return
-            except (httpx.TimeoutException, httpx.NetworkError, TransientError, PermanentError, ValueError) as exc:
+            except (httpx.TimeoutException, httpx.NetworkError, TransientError, PermanentError, ValueError, OSError) as exc:
                 last_error, should_retry = self._classify_error(exc)
 
                 if not should_retry:

--- a/collector/intelligence/__init__.py
+++ b/collector/intelligence/__init__.py
@@ -5,7 +5,8 @@ The main entry point is the :class:`TraceIntelligence` class.
 """
 
 from .facade import TraceIntelligence
-from .helpers import event_value as _event_value, mean as _mean
+from .helpers import event_value as _event_value
+from .helpers import mean as _mean
 
 __all__ = [
     "TraceIntelligence",

--- a/collector/intelligence/compute.py
+++ b/collector/intelligence/compute.py
@@ -7,8 +7,8 @@ from typing import Any
 
 from agent_debugger_sdk.core.events import Checkpoint, EventType, TraceEvent
 
-from .helpers import event_value
 from .event_utils import retention_tier
+from .helpers import event_value
 
 
 def compute_event_ranking(

--- a/collector/intelligence/facade.py
+++ b/collector/intelligence/facade.py
@@ -15,7 +15,8 @@ from ..highlights import generate_highlights
 from ..live_monitor import LiveMonitor
 from ..ranking import CheckpointRankingService, EventRankingService
 from .compute import compute_checkpoint_rankings, compute_event_ranking, detect_tool_loop
-from .event_utils import event_headline, fingerprint as fingerprint_fn, retention_tier
+from .event_utils import event_headline, retention_tier
+from .event_utils import fingerprint as fingerprint_fn
 from .helpers import event_value, mean
 
 


### PR DESCRIPTION
## Summary

Fixes #101 by adding `OSError` (which covers `ConnectionError`, `BrokenPipeError`, and other OS-level connection errors) to the exception types caught by `HttpTransport._send_with_retry`.

## Changes

- ✅ Add `OSError` to the exception tuple in `_send_with_retry`
- ✅ Classify `OSError` as a transient error in `_classify_error`
- ✅ Fix 3 ruff I001 import ordering errors in `collector/intelligence/`

## Root Cause

The `_send_with_retry` method only caught `httpx` exception types (`httpx.TimeoutException`, `httpx.NetworkError`) but not Python's built-in `ConnectionError` (a subclass of `OSError`). When the underlying HTTP client raises a plain `ConnectionError`, it propagates uncaught and breaks agent execution.

## Impact

- Three tests in `tests/test_sdk_transport.py` will now pass:
  - `test_transport_graceful_on_failure`
  - `test_transport_send_session_start_graceful_on_failure`
  - `test_transport_send_session_update_graceful_on_failure`
- Agent execution will no longer crash on OS-level connection errors; instead it will retry with exponential backoff

## Testing

- ✅ Ruff validation: `ruff check .` passes
- ✅ Code changes address the exact issue described in #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)