### PR TITLE
fix: implement missing collector modules and resolve 42 test failures (#104)

### DIFF
--- a/collector/behavior_monitor.py
+++ b/collector/behavior_monitor.py
@@ -1,0 +1,120 @@
+"""Behavior change detection by comparing baseline and recent session metrics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class BehaviorChange:
+    """Represents a detected behavior change between baseline and recent periods."""
+
+    type: str  # e.g., "decision_pattern_shift", "latency_increase", "failure_rate_spike"
+    severity: str  # "low", "medium", "high"
+    before: Any  # Baseline value
+    after: Any  # Current/recent value
+    root_cause: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to dictionary."""
+        return {
+            "type": self.type,
+            "severity": self.severity,
+            "before": self.before,
+            "after": self.after,
+            "root_cause": self.root_cause,
+        }
+
+
+class BehaviorMonitor:
+    """Detects significant behavioral changes between a baseline and recent period."""
+
+    _LATENCY_THRESHOLD = 0.50  # flag if latency increases by > 50%
+    _FAILURE_RATE_MULTIPLIER = 2.0  # flag if failure rate exceeds 2x baseline
+    _COST_MULTIPLIER = 2.0  # flag if cost exceeds 2x baseline
+    _DISTRIBUTION_SHIFT_THRESHOLD = 0.20  # total variation distance threshold
+    _MIN_BASELINE_DAYS = 7
+    _MIN_BASELINE_SESSIONS = 15
+
+    def detect_changes(
+        self, baseline: dict[str, Any], recent: dict[str, Any]
+    ) -> list[BehaviorChange]:
+        """Compare baseline and recent metrics and return significant changes."""
+        if (
+            baseline.get("time_window_days", 0) < self._MIN_BASELINE_DAYS
+            or baseline.get("session_count", 0) < self._MIN_BASELINE_SESSIONS
+        ):
+            return []
+
+        changes: list[BehaviorChange] = []
+
+        # Latency check
+        try:
+            b_lat = baseline.get("avg_latency_ms")
+            r_lat = recent.get("avg_latency_ms")
+            if b_lat is not None and r_lat is not None and b_lat > 0:
+                if r_lat / b_lat > 1 + self._LATENCY_THRESHOLD:
+                    changes.append(
+                        BehaviorChange(type="latency_increase", severity="medium", before=b_lat, after=r_lat)
+                    )
+        except Exception:
+            pass
+
+        # Failure rate check
+        try:
+            b_fr = baseline.get("failure_rate")
+            r_fr = recent.get("failure_rate")
+            if b_fr is not None and r_fr is not None and b_fr > 0:
+                if r_fr / b_fr > self._FAILURE_RATE_MULTIPLIER:
+                    changes.append(
+                        BehaviorChange(type="failure_rate_spike", severity="high", before=b_fr, after=r_fr)
+                    )
+        except Exception:
+            pass
+
+        # Cost check
+        try:
+            b_cost = baseline.get("avg_cost_per_session")
+            r_cost = recent.get("avg_cost_per_session")
+            if b_cost is not None and r_cost is not None and b_cost > 0:
+                if r_cost / b_cost > self._COST_MULTIPLIER:
+                    changes.append(
+                        BehaviorChange(type="cost_increase", severity="high", before=b_cost, after=r_cost)
+                    )
+        except Exception:
+            pass
+
+        # Decision distribution check
+        try:
+            b_dist = baseline.get("decision_distribution")
+            r_dist = recent.get("decision_distribution")
+            if b_dist and r_dist:
+                all_keys = set(b_dist) | set(r_dist)
+                total_diff = sum(abs(b_dist.get(k, 0) - r_dist.get(k, 0)) for k in all_keys)
+                if total_diff > self._DISTRIBUTION_SHIFT_THRESHOLD:
+                    changes.append(
+                        BehaviorChange(
+                            type="decision_pattern_shift",
+                            severity="medium",
+                            before=b_dist,
+                            after=r_dist,
+                        )
+                    )
+        except Exception:
+            pass
+
+        return changes
+
+    def identify_root_cause(
+        self,
+        baseline: dict[str, Any],
+        recent: dict[str, Any],
+        change: BehaviorChange,
+    ) -> str | None:
+        """Attempt to identify the root cause of a detected behavior change."""
+        b_config = baseline.get("config_version")
+        r_config = recent.get("config_version")
+        if b_config is not None and r_config is not None and b_config != r_config:
+            return f"Configuration change detected: version changed from {b_config} to {r_config}"
+        return None

--- a/collector/failure_memory.py
+++ b/collector/failure_memory.py
@@ -1,0 +1,166 @@
+"""Failure memory for similarity-based failure search."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+from agent_debugger_sdk.core.events import EventType, TraceEvent
+
+
+class EmbeddingGenerationError(Exception):
+    """Raised when embedding generation fails."""
+
+
+@dataclass
+class FailureSignature:
+    """Signature extracted from a failure event for embedding."""
+
+    error_type: str
+    error_message: str
+    tool_name: str | None = None
+    session_id: str | None = None
+    additional_context: dict[str, Any] = field(default_factory=dict)
+
+    def to_text(self) -> str:
+        """Convert signature to text for embedding."""
+        parts = [f"Error: {self.error_type}", f"Message: {self.error_message}"]
+        if self.tool_name:
+            parts.append(f"Tool: {self.tool_name}")
+        return " | ".join(parts)
+
+
+@dataclass
+class SimilarFailureMatch:
+    """A match from the failure memory search."""
+
+    failure_id: str
+    similarity_score: float
+    signature: FailureSignature
+    fix_applied: str | None = None
+    occurrence_count: int = 1
+    session_id: str | None = None
+
+
+class FailureMemory:
+    """Stores and searches failure embeddings for similarity-based lookup."""
+
+    _DUPLICATE_DISTANCE_THRESHOLD = 0.05
+
+    def __init__(self, embedding_model: Any, vector_db: Any) -> None:
+        self._embedding_model = embedding_model
+        self._vector_db = vector_db
+
+    @staticmethod
+    def extract_signature(error_event: TraceEvent) -> FailureSignature:
+        """Extract a failure signature from an error event."""
+        data = error_event.data or {}
+        return FailureSignature(
+            error_type=data.get("error_type", "Unknown"),
+            error_message=data.get("error_message", ""),
+            tool_name=data.get("tool_name"),
+            session_id=error_event.session_id,
+        )
+
+    def _generate_embedding(self, text: str) -> list[float]:
+        try:
+            return self._embedding_model.encode(text)
+        except Exception as exc:
+            raise EmbeddingGenerationError(str(exc)) from exc
+
+    def remember_failure(self, error_event: TraceEvent, fix_applied: str | None = None) -> None:
+        """Store a failure embedding, updating occurrence count for near-duplicates."""
+        signature = self.extract_signature(error_event)
+        embedding = self._generate_embedding(signature.to_text())
+
+        existing = self._vector_db.query(
+            query_embeddings=[embedding],
+            n_results=1,
+        )
+
+        ids = existing.get("ids", [])
+        distances = existing.get("distances", [])
+        metadatas = existing.get("metadatas", [])
+
+        if ids and distances and distances[0] <= self._DUPLICATE_DISTANCE_THRESHOLD:
+            existing_id = ids[0]
+            existing_meta = (metadatas[0] if metadatas else None) or {}
+            new_count = existing_meta.get("occurrence_count", 1) + 1
+            self._vector_db.update(
+                id=existing_id,
+                metadata={
+                    **existing_meta,
+                    "occurrence_count": new_count,
+                    "fix_applied": fix_applied or existing_meta.get("fix_applied"),
+                },
+            )
+        else:
+            failure_id = str(uuid.uuid4())
+            self._vector_db.add(
+                embeddings=[embedding],
+                ids=[failure_id],
+                metadata={
+                    "error_type": signature.error_type,
+                    "error_message": signature.error_message,
+                    "tool_name": signature.tool_name,
+                    "session_id": signature.session_id,
+                    "fix_applied": fix_applied,
+                    "occurrence_count": 1,
+                },
+            )
+
+    def search_similar(self, error_event: TraceEvent, threshold: float = 0.5) -> list[SimilarFailureMatch]:
+        """Return failures similar to the given event, ranked by similarity score."""
+        try:
+            signature = self.extract_signature(error_event)
+            embedding = self._generate_embedding(signature.to_text())
+            results = self._vector_db.query(
+                query_embeddings=[embedding],
+                n_results=10,
+            )
+        except (ConnectionError, EmbeddingGenerationError):
+            return []
+
+        ids = results.get("ids", [])
+        distances = results.get("distances", [])
+        metadatas = results.get("metadatas", [])
+
+        matches: list[SimilarFailureMatch] = []
+        for i, failure_id in enumerate(ids):
+            dist = distances[i] if i < len(distances) else 1.0
+            meta = (metadatas[i] if i < len(metadatas) else None) or {}
+
+            similarity_score = 1.0 - dist
+            if similarity_score < threshold:
+                continue
+
+            sig = FailureSignature(
+                error_type=meta.get("error_type", "Unknown"),
+                error_message=meta.get("error_message", ""),
+                tool_name=meta.get("tool_name"),
+                session_id=meta.get("session_id"),
+            )
+            matches.append(
+                SimilarFailureMatch(
+                    failure_id=failure_id,
+                    similarity_score=similarity_score,
+                    signature=sig,
+                    fix_applied=meta.get("fix_applied"),
+                    occurrence_count=meta.get("occurrence_count", 1),
+                    session_id=meta.get("session_id"),
+                )
+            )
+
+        matches.sort(key=lambda m: m.similarity_score, reverse=True)
+        return matches
+
+    def remember_session_failures(self, session: dict[str, Any]) -> bool | list[TraceEvent]:
+        """Store all error events from a session. Returns False if no errors found."""
+        events = session.get("events", [])
+        error_events = [e for e in events if hasattr(e, "event_type") and e.event_type == EventType.ERROR]
+        if not error_events:
+            return False
+        for event in error_events:
+            self.remember_failure(event)
+        return error_events

--- a/collector/intelligence/__init__.py
+++ b/collector/intelligence/__init__.py
@@ -5,7 +5,8 @@ The main entry point is the :class:`TraceIntelligence` class.
 """
 
 from .facade import TraceIntelligence
-from .helpers import event_value as _event_value, mean as _mean
+from .helpers import event_value as _event_value
+from .helpers import mean as _mean
 
 __all__ = [
     "TraceIntelligence",

--- a/collector/intelligence/compute.py
+++ b/collector/intelligence/compute.py
@@ -7,8 +7,8 @@ from typing import Any
 
 from agent_debugger_sdk.core.events import Checkpoint, EventType, TraceEvent
 
-from .helpers import event_value
 from .event_utils import retention_tier
+from .helpers import event_value
 
 
 def compute_event_ranking(

--- a/collector/intelligence/facade.py
+++ b/collector/intelligence/facade.py
@@ -15,7 +15,8 @@ from ..highlights import generate_highlights
 from ..live_monitor import LiveMonitor
 from ..ranking import CheckpointRankingService, EventRankingService
 from .compute import compute_checkpoint_rankings, compute_event_ranking, detect_tool_loop
-from .event_utils import event_headline, fingerprint as fingerprint_fn, retention_tier
+from .event_utils import event_headline, retention_tier
+from .event_utils import fingerprint as fingerprint_fn
 from .helpers import event_value, mean
 
 

--- a/tests/test_feature_2_failure_memory.py
+++ b/tests/test_feature_2_failure_memory.py
@@ -8,62 +8,13 @@ This module tests the FailureMemory class which provides:
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
 from agent_debugger_sdk.core.events import EventType, TraceEvent
-
-# Note: Feature 2 (failure_memory) tests are implemented but feature module may not exist yet
-
-
-# =============================================================================
-# Custom Exceptions
-# =============================================================================
-
-
-class EmbeddingGenerationError(Exception):
-    """Raised when embedding generation fails."""
-
-    pass
-
-
-# =============================================================================
-# Mock Data Classes for FailureMemory
-# =============================================================================
-
-
-@dataclass
-class FailureSignature:
-    """Signature extracted from a failure event for embedding."""
-
-    error_type: str
-    error_message: str
-    tool_name: str | None = None
-    session_id: str | None = None
-    additional_context: dict[str, Any] = field(default_factory=dict)
-
-    def to_text(self) -> str:
-        """Convert signature to text for embedding."""
-        parts = [f"Error: {self.error_type}", f"Message: {self.error_message}"]
-        if self.tool_name:
-            parts.append(f"Tool: {self.tool_name}")
-        return " | ".join(parts)
-
-
-@dataclass
-class SimilarFailureMatch:
-    """A match from the failure memory search."""
-
-    failure_id: str
-    similarity_score: float
-    signature: FailureSignature
-    fix_applied: str | None = None
-    occurrence_count: int = 1
-    session_id: str | None = None
-
+from collector.failure_memory import EmbeddingGenerationError, SimilarFailureMatch
 
 # =============================================================================
 # Fixtures

--- a/tests/test_feature_5_nl_debugging.py
+++ b/tests/test_feature_5_nl_debugging.py
@@ -203,6 +203,8 @@ def create_debugger(llm_client):
 
             return Context(events=relevant)
 
+    return NaturalLanguageDebugger(llm_client)
+
 
 # Test Classes
 


### PR DESCRIPTION
## Summary

Fixes acailic/agent_debugger#104 — 42 test failures and 3 ruff lint errors found in the test suite.

- **Add `collector/failure_memory.py`**: `FailureMemory` class for embedding-based similarity search over past failures. Supports storing failures with deduplication (by distance threshold), searching similar failures with configurable similarity threshold, and processing full sessions. Exports `EmbeddingGenerationError`, `FailureSignature`, `SimilarFailureMatch`.
- **Add `collector/behavior_monitor.py`**: `BehaviorMonitor` class comparing baseline vs recent session metrics. Detects latency increases (>50%), failure rate spikes (>2x), cost increases (>2x), and decision distribution shifts. Handles missing/zero metrics gracefully. Includes `identify_root_cause` for config-change detection.
- **Fix `tests/test_feature_2_failure_memory.py`**: Replace local stub class definitions with imports from the new module.
- **Fix `tests/test_feature_5_nl_debugging.py`**: Add missing `return NaturalLanguageDebugger(llm_client)` in `create_debugger()` — without it every test got `AttributeError: 'NoneType'`.
- **Fix `collector/intelligence/` import sorting**: Auto-fixed 3 ruff `I001` violations in `__init__.py`, `compute.py`, `facade.py`.

## Test plan

- [ ] `ruff check .` → `All checks passed!`
- [ ] `python3 -m pytest -q tests/test_feature_2_failure_memory.py tests/test_feature_4_behavior_alerts.py tests/test_feature_5_nl_debugging.py` → 42 passed
- [ ] Full suite: `python3 -m pytest -q` → 1328 passed, 54 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)