### PR TITLE
fix: use relative dates in test_get_cost_summary_daily_breakdown

### DIFF
--- a/tests/test_cost_routes.py
+++ b/tests/test_cost_routes.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -276,25 +276,26 @@ async def test_get_cost_summary_daily_breakdown():
         # Create sessions across multiple days
         async with app_context.require_session_maker()() as db_session:
             repo = TraceRepository(db_session)
+            now = datetime.now(timezone.utc)
             await repo.create_session(
                 _make_session(
                     "cost-daily-1",
                     total_cost_usd=1.00,
-                    started_at=datetime(2026, 4, 1, 10, 0, tzinfo=timezone.utc),
+                    started_at=(now - timedelta(days=2)).replace(hour=10, minute=0, second=0, microsecond=0),
                 )
             )
             await repo.create_session(
                 _make_session(
                     "cost-daily-2",
                     total_cost_usd=2.50,
-                    started_at=datetime(2026, 4, 2, 10, 0, tzinfo=timezone.utc),
+                    started_at=(now - timedelta(days=1)).replace(hour=10, minute=0, second=0, microsecond=0),
                 )
             )
             await repo.create_session(
                 _make_session(
                     "cost-daily-3",
                     total_cost_usd=1.75,
-                    started_at=datetime(2026, 4, 2, 15, 0, tzinfo=timezone.utc),
+                    started_at=(now - timedelta(days=1)).replace(hour=15, minute=0, second=0, microsecond=0),
                 )
             )
             await db_session.commit()

--- a/tests/test_cost_routes.py
+++ b/tests/test_cost_routes.py
@@ -27,7 +27,7 @@ def _make_session(
         agent_name="test_agent",
         framework=framework,
         started_at=_started,
-        ended_at=_started.replace(hour=11),
+        ended_at=_started + timedelta(hours=1),
         status=SessionStatus.COMPLETED,
         total_cost_usd=total_cost_usd,
         total_tokens=total_tokens,


### PR DESCRIPTION
## Summary

- Replaces hardcoded dates (`2026-04-01`, `2026-04-02`) in `test_get_cost_summary_daily_breakdown` with `datetime.now(UTC) - timedelta(days=N)`
- The 7d range query was filtering out the sessions because the fixed dates became more than 7 days old, causing `daily_sum` to return `0.0 >= 5.25` assertion failure
- Sessions now always land within the rolling 7-day window regardless of when the test runs

Fixes #146

## Test plan

- [x] `pytest tests/test_cost_routes.py::test_get_cost_summary_daily_breakdown` passes
- [x] Full suite: 2333 passed, 28 skipped, 0 failed
- [x] `ruff check .` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)