### PR TITLE
fix: include [dev] extras in install-dev to fix pytest-timeout missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,7 @@ install:
 	pip install -e ".[server]"
 
 install-dev:
-	pip install -e ".[server,langchain,pydantic-ai,crewai]"
-	pip install pytest pytest-asyncio ruff
+	pip install -e ".[server,langchain,pydantic-ai,crewai,dev]"
 
 API_PORT ?= 8000
 


### PR DESCRIPTION
## Summary

- Replaces the manual, incomplete `pip install pytest pytest-asyncio ruff` line in `make install-dev` with `.[dev]` extras group
- The `[dev]` group in `pyproject.toml` already declares all required test dependencies (`pytest-timeout`, `pytest-xdist`, `pytest-cov`, `respx`, `ruff`, etc.)
- New contributors can now run `make install-dev && make test` without hitting the `--timeout=120` unrecognized argument error

## Test plan

- [ ] `make install-dev` installs `pytest-timeout` via the `[dev]` extras
- [ ] `make test` runs without the `unrecognized arguments: --timeout=120` error
- [ ] `ruff check .` passes (no changes to Python source)

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)