### PR TITLE
fix: include [dev] extras in install-dev to fix make test for new contributors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,7 @@ install:
 	pip install -e ".[server]"
 
 install-dev:
-	pip install -e ".[server,langchain,pydantic-ai,crewai]"
-	pip install pytest pytest-asyncio ruff
+	pip install -e ".[server,langchain,pydantic-ai,crewai,dev]"
 
 API_PORT ?= 8000
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,15 @@ dependencies = [
 langchain = ["langchain-core>=0.2"]
 crewai = ["crewai>=0.40"]
 pydantic-ai = ["pydantic-ai>=0.0.10"]
+server = [
+    "fastapi>=0.100",
+    "uvicorn[standard]>=0.20",
+    "sqlalchemy[asyncio]>=2.0",
+    "aiosqlite>=0.19",
+    "alembic>=1.12",
+    "aiofiles>=23.0",
+    "bcrypt>=4.0",
+]
 all = [
     "langchain-core>=0.2",
     "crewai>=0.40",


### PR DESCRIPTION
## Summary

- Fixes `make install-dev` omitting `pytest-timeout`, `pytest-xdist`, `pytest-cov`, and `respx` from the dev install
- Replaces the manual, out-of-sync pip list with a single `pip install -e ".[server,langchain,pydantic-ai,crewai,dev]"` invocation
- New contributors can now run `make install-dev && make test` without hitting `unrecognized arguments: --timeout=120`

Closes #154

## Test plan

- [ ] `make install-dev` in a fresh virtualenv succeeds
- [ ] `make test` passes after `make install-dev` (no `--timeout=120` error)
- [ ] `ruff check .` passes (confirmed locally: all checks passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)