### PR TITLE
test: add unit tests for InsightBuilder and MemoryExporterHook (zero coverage)

### DIFF
--- a/tests/test_insight_builder.py
+++ b/tests/test_insight_builder.py
@@ -17,7 +17,6 @@ from agent_debugger_sdk.core.exporters.pipeline import (
 )
 from storage.entities import EntityType
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------

--- a/tests/test_insight_builder.py
+++ b/tests/test_insight_builder.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-import logging
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from agent_debugger_sdk.core.events import Session
-from agent_debugger_sdk.core.events.base import SessionStatus
 from agent_debugger_sdk.core.exporters import TraceInsight
 from agent_debugger_sdk.core.exporters.insights import InsightBuilder
 from agent_debugger_sdk.core.exporters.pipeline import (
@@ -18,372 +17,365 @@ from agent_debugger_sdk.core.exporters.pipeline import (
 )
 from storage.entities import EntityType
 
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 
 
 @pytest.fixture
-def session():
+def completed_session():
     return Session(
-        id="sess-abc",
+        id="sess-001",
         agent_name="test-agent",
         framework="pytest",
-        started_at=datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
-        ended_at=datetime(2026, 1, 1, 0, 5, tzinfo=timezone.utc),
-        status=SessionStatus.COMPLETED,
-        total_tokens=200,
-        total_cost_usd=0.02,
-        tool_calls=4,
-        llm_calls=2,
-        errors=1,
-        tags=["ci"],
-        fix_note="fixed by patch",
+        started_at=datetime(2026, 1, 1, 10, 0, tzinfo=timezone.utc),
+        ended_at=datetime(2026, 1, 1, 10, 5, tzinfo=timezone.utc),
+        status="completed",
+        total_tokens=500,
+        total_cost_usd=0.05,
+        tool_calls=10,
+        llm_calls=3,
+        errors=2,
+        tags=["prod", "v2"],
+        fix_note="fixed by retry",
     )
 
 
 @pytest.fixture
-def running_session(session):
+def running_session():
     return Session(
-        id="sess-running",
+        id="sess-002",
         agent_name="test-agent",
         framework="pytest",
-        started_at=datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
-        status=SessionStatus.RUNNING,
+        status="running",
     )
 
 
 @pytest.fixture
-def analysis():
+def minimal_analysis():
     return {
-        "session_replay_value": 0.8,
+        "session_replay_value": 0.9,
         "retention_tier": "standard",
         "highlights": ["h1", "h2"],
         "session_summary": {"failure_count": 2, "behavior_alert_count": 1},
-        "live_summary": {"timestamp": "2026-01-01T00:05:00Z"},
-        "failure_clusters": [
-            {
-                "fingerprint": "RuntimeError:tool_fail",
-                "count": 5,
-                "representative_event_id": "evt-1",
-                "event_ids": ["evt-1", "evt-2"],
-            },
-            {
-                "fingerprint": "ValueError:bad_input",
-                "count": 3,
-                "representative_event_id": "evt-3",
-                "event_ids": ["evt-3"],
-            },
-        ],
-        "event_rankings": [
-            {
-                "event_id": "evt-1",
-                "timestamp": "2026-01-01T00:01:00Z",
-                "severity": 0.9,
-                "fingerprint": "error:RuntimeError",
-            },
-            {
-                "event_id": "evt-2",
-                "timestamp": "2026-01-01T00:02:00Z",
-                "severity": 0.7,
-                "fingerprint": "error:ValueError",
-            },
-            {
-                "event_id": "evt-3",
-                "timestamp": "2026-01-01T00:03:00Z",
-                "severity": 0.6,
-                "fingerprint": "other:blah",
-            },
-        ],
+        "failure_clusters": [],
+        "event_rankings": [],
+        "live_summary": {"timestamp": "2026-01-01T10:05:00Z"},
     }
 
 
 @pytest.fixture
-def entity_data():
-    return {
-        EntityType.TOOL_NAME: [
-            {"value": "search", "count": 10, "session_count": 3},
-            {"value": "write", "count": 5, "session_count": 2},
-            {"value": "read", "count": 4, "session_count": 1},
-            {"value": "exec", "count": 3, "session_count": 1},
-            {"value": "delete", "count": 2, "session_count": 1},
-            {"value": "extra", "count": 1, "session_count": 1},  # 6th → should be capped
-        ],
-        EntityType.ERROR_TYPE: [
-            {"value": "RuntimeError", "count": 5, "session_count": 2},
-        ],
-    }
+def builder():
+    return InsightBuilder()
+
+
+class MockExporter:
+    def __init__(self):
+        self.export = AsyncMock()
+        self.query_similar = AsyncMock(return_value=[])
+        self.get_failure_patterns = AsyncMock(return_value=[])
+        self.health_check = AsyncMock(return_value={"status": "healthy"})
 
 
 # ---------------------------------------------------------------------------
-# InsightBuilder — build_insight
+# InsightBuilder.build_insight
 # ---------------------------------------------------------------------------
 
 
-def test_build_insight_returns_trace_insight(session, analysis):
-    builder = InsightBuilder()
-    insight = builder.build_insight(session, events=[], checkpoints=[], analysis=analysis)
+def test_build_insight_returns_trace_insight(builder, completed_session, minimal_analysis):
+    insight = builder.build_insight(
+        session=completed_session,
+        events=[],
+        checkpoints=[],
+        analysis=minimal_analysis,
+    )
 
     assert isinstance(insight, TraceInsight)
-    assert insight.session_digest is not None
-    assert isinstance(insight.failure_patterns, list)
-    assert isinstance(insight.entity_summaries, list)
-    assert isinstance(insight.metadata, dict)
-
-
-def test_build_insight_metadata_counts(session, analysis):
-    from agent_debugger_sdk.core.events import Checkpoint, TraceEvent
-
-    events = [MagicMock(spec=TraceEvent), MagicMock(spec=TraceEvent)]
-    checkpoints = [MagicMock(spec=Checkpoint)]
-
-    builder = InsightBuilder()
-    insight = builder.build_insight(session, events=events, checkpoints=checkpoints, analysis=analysis)
-
-    assert insight.metadata["event_count"] == 2
-    assert insight.metadata["checkpoint_count"] == 1
-    assert insight.metadata["analysis_timestamp"] == "2026-01-01T00:05:00Z"
-
-
-def test_build_insight_no_entity_data(session, analysis):
-    builder = InsightBuilder()
-    insight = builder.build_insight(session, events=[], checkpoints=[], analysis=analysis, entity_data=None)
-
+    assert insight.session_digest.session_id == "sess-001"
+    assert insight.failure_patterns == []
     assert insight.entity_summaries == []
 
 
+def test_build_insight_metadata(builder, completed_session, minimal_analysis):
+    events = [MagicMock(), MagicMock()]
+    checkpoints = [MagicMock()]
+
+    insight = builder.build_insight(
+        session=completed_session,
+        events=events,
+        checkpoints=checkpoints,
+        analysis=minimal_analysis,
+    )
+
+    assert insight.metadata["event_count"] == 2
+    assert insight.metadata["checkpoint_count"] == 1
+    assert insight.metadata["analysis_timestamp"] == "2026-01-01T10:05:00Z"
+
+
+def test_build_insight_metadata_missing_timestamp(builder, completed_session):
+    insight = builder.build_insight(
+        session=completed_session,
+        events=[],
+        checkpoints=[],
+        analysis={},
+    )
+
+    assert insight.metadata["analysis_timestamp"] is None
+
+
 # ---------------------------------------------------------------------------
-# InsightBuilder — _build_session_digest
+# InsightBuilder._build_session_digest
 # ---------------------------------------------------------------------------
 
 
-def test_build_session_digest_maps_fields(session, analysis):
-    builder = InsightBuilder()
-    digest = builder._build_session_digest(session, analysis)
+def test_build_session_digest_maps_fields(builder, completed_session, minimal_analysis):
+    digest = builder._build_session_digest(completed_session, minimal_analysis)
 
-    assert digest.session_id == session.id
-    assert digest.agent_name == session.agent_name
-    assert digest.framework == session.framework
-    assert digest.started_at == session.started_at.isoformat()
-    assert digest.ended_at == session.ended_at.isoformat()
-    assert digest.status == str(session.status)
-    assert digest.total_tokens == session.total_tokens
-    assert digest.total_cost_usd == session.total_cost_usd
-    assert digest.tool_calls == session.tool_calls
-    assert digest.llm_calls == session.llm_calls
-    assert digest.errors == session.errors
-    assert digest.tags == session.tags
-    assert digest.fix_note == session.fix_note
+    assert digest.session_id == "sess-001"
+    assert digest.agent_name == "test-agent"
+    assert digest.framework == "pytest"
+    assert digest.status == "completed"
+    assert digest.total_tokens == 500
+    assert digest.total_cost_usd == 0.05
+    assert digest.tool_calls == 10
+    assert digest.llm_calls == 3
+    assert digest.errors == 2
+    assert digest.tags == ["prod", "v2"]
+    assert digest.fix_note == "fixed by retry"
 
 
-def test_build_session_digest_analysis_fields(session, analysis):
-    builder = InsightBuilder()
-    digest = builder._build_session_digest(session, analysis)
+def test_build_session_digest_analysis_fields(builder, completed_session, minimal_analysis):
+    digest = builder._build_session_digest(completed_session, minimal_analysis)
 
-    assert digest.replay_value == 0.8
+    assert digest.replay_value == 0.9
     assert digest.retention_tier == "standard"
+    assert digest.highlights_count == 2
     assert digest.failure_count == 2
     assert digest.behavior_alert_count == 1
-    assert digest.highlights_count == 2
 
 
-def test_build_session_digest_no_ended_at(analysis):
-    running = Session(
-        id="sess-run",
-        agent_name="bot",
-        status=SessionStatus.RUNNING,
-    )
-    builder = InsightBuilder()
-    digest = builder._build_session_digest(running, analysis)
-
-    assert digest.ended_at is None
-
-
-def test_build_session_digest_defaults_for_empty_analysis(session):
-    builder = InsightBuilder()
-    digest = builder._build_session_digest(session, {})
+def test_build_session_digest_defaults_on_empty_analysis(builder, completed_session):
+    digest = builder._build_session_digest(completed_session, {})
 
     assert digest.replay_value == 0.0
     assert digest.retention_tier == "downsampled"
+    assert digest.highlights_count == 0
     assert digest.failure_count == 0
     assert digest.behavior_alert_count == 0
-    assert digest.highlights_count == 0
+
+
+def test_build_session_digest_none_ended_at(builder):
+    session = Session(
+        id="sess-no-end",
+        agent_name="",
+        framework="",
+        status="running",
+    )
+    digest = builder._build_session_digest(session, {})
+
+    assert digest.ended_at is None
+    assert digest.started_at != ""
 
 
 # ---------------------------------------------------------------------------
-# InsightBuilder — _build_failure_patterns
+# InsightBuilder._build_failure_patterns
 # ---------------------------------------------------------------------------
 
 
-def test_build_failure_patterns_sorted_by_count_desc(analysis):
-    builder = InsightBuilder()
-    patterns = builder._build_failure_patterns(analysis)
-
-    assert patterns[0].count >= patterns[1].count
-
-
-def test_build_failure_patterns_fingerprints(analysis):
-    builder = InsightBuilder()
-    patterns = builder._build_failure_patterns(analysis)
-
-    fingerprints = [p.fingerprint for p in patterns]
-    assert "RuntimeError:tool_fail" in fingerprints
-    assert "ValueError:bad_input" in fingerprints
+def _make_cluster(fingerprint: str, count: int, rep_id: str, event_ids: list[str]) -> dict[str, Any]:
+    return {
+        "fingerprint": fingerprint,
+        "count": count,
+        "representative_event_id": rep_id,
+        "event_ids": event_ids,
+    }
 
 
-def test_build_failure_patterns_caps_at_20():
-    clusters = [
-        {"fingerprint": f"fp-{i}", "count": i, "representative_event_id": f"evt-{i}", "event_ids": []}
-        for i in range(25)
-    ]
-    analysis = {"failure_clusters": clusters, "event_rankings": []}
-
-    builder = InsightBuilder()
-    patterns = builder._build_failure_patterns(analysis)
-
-    assert len(patterns) <= 20
+def _make_ranking(event_id: str, timestamp: str, severity: float, fingerprint: str = "") -> dict[str, Any]:
+    return {
+        "event_id": event_id,
+        "timestamp": timestamp,
+        "severity": severity,
+        "fingerprint": fingerprint,
+    }
 
 
-def test_build_failure_patterns_extracts_error_types_from_fingerprint():
+def test_build_failure_patterns_sorted_by_count_descending(builder):
     analysis = {
         "failure_clusters": [
-            {
-                "fingerprint": "fp-err",
-                "count": 2,
-                "representative_event_id": "e1",
-                "event_ids": ["e1"],
-            }
+            _make_cluster("fp-a", 1, "e1", ["e1"]),
+            _make_cluster("fp-b", 5, "e2", ["e2"]),
+            _make_cluster("fp-c", 3, "e3", ["e3"]),
         ],
         "event_rankings": [
-            {
-                "event_id": "e1",
-                "timestamp": "2026-01-01T00:00:00Z",
-                "severity": 0.8,
-                "fingerprint": "MyError:some_context",
-            }
+            _make_ranking("e1", "2026-01-01T10:01:00Z", 0.4),
+            _make_ranking("e2", "2026-01-01T10:02:00Z", 0.8),
+            _make_ranking("e3", "2026-01-01T10:03:00Z", 0.6),
         ],
     }
-    builder = InsightBuilder()
+
+    patterns = builder._build_failure_patterns(analysis)
+
+    assert len(patterns) == 3
+    assert patterns[0].count == 5
+    assert patterns[1].count == 3
+    assert patterns[2].count == 1
+
+
+def test_build_failure_patterns_capped_at_20(builder):
+    clusters = [_make_cluster(f"fp-{i}", i + 1, f"e{i}", [f"e{i}"]) for i in range(25)]
+    analysis = {"failure_clusters": clusters, "event_rankings": []}
+
+    patterns = builder._build_failure_patterns(analysis)
+
+    assert len(patterns) == 20
+
+
+def test_build_failure_patterns_extracts_error_types_from_fingerprint(builder):
+    analysis = {
+        "failure_clusters": [
+            _make_cluster("RuntimeError:search", 2, "e1", ["e2"]),
+        ],
+        "event_rankings": [
+            _make_ranking("e1", "2026-01-01T10:00:00Z", 0.7),
+            _make_ranking("e2", "2026-01-01T10:00:00Z", 0.7, fingerprint="RuntimeError:search"),
+        ],
+    }
+
     patterns = builder._build_failure_patterns(analysis)
 
     assert len(patterns) == 1
-    assert patterns[0].sample_error_types == ["MyError"]
+    assert patterns[0].fingerprint == "RuntimeError:search"
+    assert "RuntimeError" in patterns[0].sample_error_types
 
 
-def test_build_failure_patterns_empty():
-    builder = InsightBuilder()
-    patterns = builder._build_failure_patterns({})
-
+def test_build_failure_patterns_empty(builder):
+    patterns = builder._build_failure_patterns({"failure_clusters": [], "event_rankings": []})
     assert patterns == []
 
 
 # ---------------------------------------------------------------------------
-# InsightBuilder — _build_entity_summaries
+# InsightBuilder._build_entity_summaries
 # ---------------------------------------------------------------------------
 
 
-def test_build_entity_summaries_none_returns_empty():
-    builder = InsightBuilder()
+def test_build_entity_summaries_returns_empty_on_none(builder):
     assert builder._build_entity_summaries(None) == []
 
 
-def test_build_entity_summaries_empty_dict_returns_empty():
-    builder = InsightBuilder()
+def test_build_entity_summaries_returns_empty_on_empty_dict(builder):
     assert builder._build_entity_summaries({}) == []
 
 
-def test_build_entity_summaries_maps_entity_types(entity_data):
-    builder = InsightBuilder()
+def test_build_entity_summaries_maps_entity_types(builder):
+    entity_data = {
+        EntityType.TOOL_NAME: [
+            {"value": "search", "count": 10, "session_count": 3},
+            {"value": "write", "count": 5, "session_count": 2},
+        ],
+        EntityType.ERROR_TYPE: [
+            {"value": "RuntimeError", "count": 4, "session_count": 1},
+        ],
+    }
+
     summaries = builder._build_entity_summaries(entity_data)
 
-    types = [s.entity_type for s in summaries]
-    assert EntityType.TOOL_NAME in types
-    assert EntityType.ERROR_TYPE in types
+    entity_types_in_summaries = {s.entity_type for s in summaries}
+    assert EntityType.TOOL_NAME in entity_types_in_summaries
+    assert EntityType.ERROR_TYPE in entity_types_in_summaries
 
 
-def test_build_entity_summaries_caps_top_entities_at_5(entity_data):
-    builder = InsightBuilder()
+def test_build_entity_summaries_caps_top_entities_at_5(builder):
+    entity_data = {
+        EntityType.TOOL_NAME: [
+            {"value": f"tool-{i}", "count": 10 - i, "session_count": 1}
+            for i in range(10)
+        ],
+    }
+
     summaries = builder._build_entity_summaries(entity_data)
 
     tool_summary = next(s for s in summaries if s.entity_type == EntityType.TOOL_NAME)
-    assert len(tool_summary.top_entities) <= 5
+    assert len(tool_summary.top_entities) == 5
 
 
-def test_build_entity_summaries_total_unique(entity_data):
-    builder = InsightBuilder()
+def test_build_entity_summaries_total_unique_reflects_full_count(builder):
+    entity_data = {
+        EntityType.MODEL: [
+            {"value": f"model-{i}", "count": 1, "session_count": 1}
+            for i in range(8)
+        ],
+    }
+
     summaries = builder._build_entity_summaries(entity_data)
 
-    tool_summary = next(s for s in summaries if s.entity_type == EntityType.TOOL_NAME)
-    assert tool_summary.total_unique == 6  # all 6 entries, not capped for total
+    model_summary = next(s for s in summaries if s.entity_type == EntityType.MODEL)
+    assert model_summary.total_unique == 8
 
 
 # ---------------------------------------------------------------------------
-# MemoryExporterHook — on_session_end
+# MemoryExporterHook.on_session_end
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_hook_does_nothing_when_exporter_none(session, analysis):
+async def test_on_session_end_does_nothing_when_no_exporter(completed_session, minimal_analysis):
     hook = MemoryExporterHook(exporter=None)
-    # Should not raise
-    await hook.on_session_end(session, events=[], checkpoints=[], analysis=analysis)
+    await hook.on_session_end(completed_session, [], [], minimal_analysis)
 
 
 @pytest.mark.asyncio
-async def test_hook_skips_export_when_not_completed(running_session, analysis):
-    exporter = AsyncMock()
+async def test_on_session_end_skips_when_not_completed(running_session, minimal_analysis):
+    exporter = MockExporter()
     hook = MemoryExporterHook(exporter=exporter, export_on_completion=True, export_on_update=False)
 
-    await hook.on_session_end(running_session, events=[], checkpoints=[], analysis=analysis)
+    await hook.on_session_end(running_session, [], [], minimal_analysis)
 
     exporter.export.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_hook_exports_when_completed(session, analysis):
-    exporter = AsyncMock()
+async def test_on_session_end_exports_when_completed(completed_session, minimal_analysis):
+    exporter = MockExporter()
     hook = MemoryExporterHook(exporter=exporter, export_on_completion=True)
 
-    await hook.on_session_end(session, events=[], checkpoints=[], analysis=analysis)
+    await hook.on_session_end(completed_session, [], [], minimal_analysis)
 
-    exporter.export.assert_called_once()
-    call_arg = exporter.export.call_args[0][0]
-    assert isinstance(call_arg, TraceInsight)
-    assert call_arg.session_digest.session_id == session.id
+    exporter.export.assert_awaited_once()
+    exported_insight = exporter.export.call_args[0][0]
+    assert isinstance(exported_insight, TraceInsight)
+    assert exported_insight.session_digest.session_id == "sess-001"
 
 
 @pytest.mark.asyncio
-async def test_hook_exports_on_update_regardless_of_status(running_session, analysis):
-    exporter = AsyncMock()
+async def test_on_session_end_export_on_update_ignores_status(running_session, minimal_analysis):
+    exporter = MockExporter()
     hook = MemoryExporterHook(exporter=exporter, export_on_completion=False, export_on_update=True)
 
-    await hook.on_session_end(running_session, events=[], checkpoints=[], analysis=analysis)
+    await hook.on_session_end(running_session, [], [], minimal_analysis)
 
-    exporter.export.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_hook_swallows_exporter_exceptions(session, analysis):
-    exporter = AsyncMock()
-    exporter.export.side_effect = RuntimeError("storage down")
-
-    hook = MemoryExporterHook(exporter=exporter, export_on_completion=True)
-
-    # Should not raise — exceptions are swallowed and logged
-    await hook.on_session_end(session, events=[], checkpoints=[], analysis=analysis)
+    exporter.export.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_hook_logs_error_on_exception(session, analysis, caplog):
-    exporter = AsyncMock()
-    exporter.export.side_effect = ValueError("boom")
-
+async def test_on_session_end_swallows_exporter_exceptions(completed_session, minimal_analysis):
+    exporter = MockExporter()
+    exporter.export.side_effect = RuntimeError("boom")
     hook = MemoryExporterHook(exporter=exporter, export_on_completion=True)
 
-    with caplog.at_level(logging.ERROR):
-        await hook.on_session_end(session, events=[], checkpoints=[], analysis=analysis)
+    await hook.on_session_end(completed_session, [], [], minimal_analysis)
 
-    assert any("Failed to export" in r.message for r in caplog.records)
+
+@pytest.mark.asyncio
+async def test_on_session_end_logs_error_on_exception(completed_session, minimal_analysis):
+    exporter = MockExporter()
+    exporter.export.side_effect = ValueError("bad data")
+    hook = MemoryExporterHook(exporter=exporter, export_on_completion=True)
+
+    with patch("agent_debugger_sdk.core.exporters.pipeline.logger") as mock_logger:
+        await hook.on_session_end(completed_session, [], [], minimal_analysis)
+        mock_logger.error.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -391,9 +383,9 @@ async def test_hook_logs_error_on_exception(session, analysis, caplog):
 # ---------------------------------------------------------------------------
 
 
-def test_create_memory_exporter_hook_returns_hook():
-    exporter = AsyncMock()
-    hook = create_memory_exporter_hook(exporter)
+def test_create_memory_exporter_hook_returns_correct_type():
+    exporter = MockExporter()
+    hook = create_memory_exporter_hook(exporter=exporter)
 
     assert isinstance(hook, MemoryExporterHook)
     assert hook.exporter is exporter
@@ -407,8 +399,13 @@ def test_create_memory_exporter_hook_default_config():
     assert hook.export_on_update is False
 
 
-def test_create_memory_exporter_hook_custom_config():
-    hook = create_memory_exporter_hook(export_on_completion=False, export_on_update=True)
+def test_create_memory_exporter_hook_passes_kwargs():
+    exporter = MockExporter()
+    hook = create_memory_exporter_hook(
+        exporter=exporter,
+        export_on_completion=False,
+        export_on_update=True,
+    )
 
     assert hook.export_on_completion is False
     assert hook.export_on_update is True

--- a/tests/test_insight_builder.py
+++ b/tests/test_insight_builder.py
@@ -1,0 +1,414 @@
+"""Unit tests for InsightBuilder and MemoryExporterHook."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agent_debugger_sdk.core.events import Session
+from agent_debugger_sdk.core.events.base import SessionStatus
+from agent_debugger_sdk.core.exporters import TraceInsight
+from agent_debugger_sdk.core.exporters.insights import InsightBuilder
+from agent_debugger_sdk.core.exporters.pipeline import (
+    MemoryExporterHook,
+    create_memory_exporter_hook,
+)
+from storage.entities import EntityType
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def session():
+    return Session(
+        id="sess-abc",
+        agent_name="test-agent",
+        framework="pytest",
+        started_at=datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
+        ended_at=datetime(2026, 1, 1, 0, 5, tzinfo=timezone.utc),
+        status=SessionStatus.COMPLETED,
+        total_tokens=200,
+        total_cost_usd=0.02,
+        tool_calls=4,
+        llm_calls=2,
+        errors=1,
+        tags=["ci"],
+        fix_note="fixed by patch",
+    )
+
+
+@pytest.fixture
+def running_session(session):
+    return Session(
+        id="sess-running",
+        agent_name="test-agent",
+        framework="pytest",
+        started_at=datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
+        status=SessionStatus.RUNNING,
+    )
+
+
+@pytest.fixture
+def analysis():
+    return {
+        "session_replay_value": 0.8,
+        "retention_tier": "standard",
+        "highlights": ["h1", "h2"],
+        "session_summary": {"failure_count": 2, "behavior_alert_count": 1},
+        "live_summary": {"timestamp": "2026-01-01T00:05:00Z"},
+        "failure_clusters": [
+            {
+                "fingerprint": "RuntimeError:tool_fail",
+                "count": 5,
+                "representative_event_id": "evt-1",
+                "event_ids": ["evt-1", "evt-2"],
+            },
+            {
+                "fingerprint": "ValueError:bad_input",
+                "count": 3,
+                "representative_event_id": "evt-3",
+                "event_ids": ["evt-3"],
+            },
+        ],
+        "event_rankings": [
+            {
+                "event_id": "evt-1",
+                "timestamp": "2026-01-01T00:01:00Z",
+                "severity": 0.9,
+                "fingerprint": "error:RuntimeError",
+            },
+            {
+                "event_id": "evt-2",
+                "timestamp": "2026-01-01T00:02:00Z",
+                "severity": 0.7,
+                "fingerprint": "error:ValueError",
+            },
+            {
+                "event_id": "evt-3",
+                "timestamp": "2026-01-01T00:03:00Z",
+                "severity": 0.6,
+                "fingerprint": "other:blah",
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def entity_data():
+    return {
+        EntityType.TOOL_NAME: [
+            {"value": "search", "count": 10, "session_count": 3},
+            {"value": "write", "count": 5, "session_count": 2},
+            {"value": "read", "count": 4, "session_count": 1},
+            {"value": "exec", "count": 3, "session_count": 1},
+            {"value": "delete", "count": 2, "session_count": 1},
+            {"value": "extra", "count": 1, "session_count": 1},  # 6th → should be capped
+        ],
+        EntityType.ERROR_TYPE: [
+            {"value": "RuntimeError", "count": 5, "session_count": 2},
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# InsightBuilder — build_insight
+# ---------------------------------------------------------------------------
+
+
+def test_build_insight_returns_trace_insight(session, analysis):
+    builder = InsightBuilder()
+    insight = builder.build_insight(session, events=[], checkpoints=[], analysis=analysis)
+
+    assert isinstance(insight, TraceInsight)
+    assert insight.session_digest is not None
+    assert isinstance(insight.failure_patterns, list)
+    assert isinstance(insight.entity_summaries, list)
+    assert isinstance(insight.metadata, dict)
+
+
+def test_build_insight_metadata_counts(session, analysis):
+    from agent_debugger_sdk.core.events import Checkpoint, TraceEvent
+
+    events = [MagicMock(spec=TraceEvent), MagicMock(spec=TraceEvent)]
+    checkpoints = [MagicMock(spec=Checkpoint)]
+
+    builder = InsightBuilder()
+    insight = builder.build_insight(session, events=events, checkpoints=checkpoints, analysis=analysis)
+
+    assert insight.metadata["event_count"] == 2
+    assert insight.metadata["checkpoint_count"] == 1
+    assert insight.metadata["analysis_timestamp"] == "2026-01-01T00:05:00Z"
+
+
+def test_build_insight_no_entity_data(session, analysis):
+    builder = InsightBuilder()
+    insight = builder.build_insight(session, events=[], checkpoints=[], analysis=analysis, entity_data=None)
+
+    assert insight.entity_summaries == []
+
+
+# ---------------------------------------------------------------------------
+# InsightBuilder — _build_session_digest
+# ---------------------------------------------------------------------------
+
+
+def test_build_session_digest_maps_fields(session, analysis):
+    builder = InsightBuilder()
+    digest = builder._build_session_digest(session, analysis)
+
+    assert digest.session_id == session.id
+    assert digest.agent_name == session.agent_name
+    assert digest.framework == session.framework
+    assert digest.started_at == session.started_at.isoformat()
+    assert digest.ended_at == session.ended_at.isoformat()
+    assert digest.status == str(session.status)
+    assert digest.total_tokens == session.total_tokens
+    assert digest.total_cost_usd == session.total_cost_usd
+    assert digest.tool_calls == session.tool_calls
+    assert digest.llm_calls == session.llm_calls
+    assert digest.errors == session.errors
+    assert digest.tags == session.tags
+    assert digest.fix_note == session.fix_note
+
+
+def test_build_session_digest_analysis_fields(session, analysis):
+    builder = InsightBuilder()
+    digest = builder._build_session_digest(session, analysis)
+
+    assert digest.replay_value == 0.8
+    assert digest.retention_tier == "standard"
+    assert digest.failure_count == 2
+    assert digest.behavior_alert_count == 1
+    assert digest.highlights_count == 2
+
+
+def test_build_session_digest_no_ended_at(analysis):
+    running = Session(
+        id="sess-run",
+        agent_name="bot",
+        status=SessionStatus.RUNNING,
+    )
+    builder = InsightBuilder()
+    digest = builder._build_session_digest(running, analysis)
+
+    assert digest.ended_at is None
+
+
+def test_build_session_digest_defaults_for_empty_analysis(session):
+    builder = InsightBuilder()
+    digest = builder._build_session_digest(session, {})
+
+    assert digest.replay_value == 0.0
+    assert digest.retention_tier == "downsampled"
+    assert digest.failure_count == 0
+    assert digest.behavior_alert_count == 0
+    assert digest.highlights_count == 0
+
+
+# ---------------------------------------------------------------------------
+# InsightBuilder — _build_failure_patterns
+# ---------------------------------------------------------------------------
+
+
+def test_build_failure_patterns_sorted_by_count_desc(analysis):
+    builder = InsightBuilder()
+    patterns = builder._build_failure_patterns(analysis)
+
+    assert patterns[0].count >= patterns[1].count
+
+
+def test_build_failure_patterns_fingerprints(analysis):
+    builder = InsightBuilder()
+    patterns = builder._build_failure_patterns(analysis)
+
+    fingerprints = [p.fingerprint for p in patterns]
+    assert "RuntimeError:tool_fail" in fingerprints
+    assert "ValueError:bad_input" in fingerprints
+
+
+def test_build_failure_patterns_caps_at_20():
+    clusters = [
+        {"fingerprint": f"fp-{i}", "count": i, "representative_event_id": f"evt-{i}", "event_ids": []}
+        for i in range(25)
+    ]
+    analysis = {"failure_clusters": clusters, "event_rankings": []}
+
+    builder = InsightBuilder()
+    patterns = builder._build_failure_patterns(analysis)
+
+    assert len(patterns) <= 20
+
+
+def test_build_failure_patterns_extracts_error_types_from_fingerprint():
+    analysis = {
+        "failure_clusters": [
+            {
+                "fingerprint": "fp-err",
+                "count": 2,
+                "representative_event_id": "e1",
+                "event_ids": ["e1"],
+            }
+        ],
+        "event_rankings": [
+            {
+                "event_id": "e1",
+                "timestamp": "2026-01-01T00:00:00Z",
+                "severity": 0.8,
+                "fingerprint": "MyError:some_context",
+            }
+        ],
+    }
+    builder = InsightBuilder()
+    patterns = builder._build_failure_patterns(analysis)
+
+    assert len(patterns) == 1
+    assert patterns[0].sample_error_types == ["MyError"]
+
+
+def test_build_failure_patterns_empty():
+    builder = InsightBuilder()
+    patterns = builder._build_failure_patterns({})
+
+    assert patterns == []
+
+
+# ---------------------------------------------------------------------------
+# InsightBuilder — _build_entity_summaries
+# ---------------------------------------------------------------------------
+
+
+def test_build_entity_summaries_none_returns_empty():
+    builder = InsightBuilder()
+    assert builder._build_entity_summaries(None) == []
+
+
+def test_build_entity_summaries_empty_dict_returns_empty():
+    builder = InsightBuilder()
+    assert builder._build_entity_summaries({}) == []
+
+
+def test_build_entity_summaries_maps_entity_types(entity_data):
+    builder = InsightBuilder()
+    summaries = builder._build_entity_summaries(entity_data)
+
+    types = [s.entity_type for s in summaries]
+    assert EntityType.TOOL_NAME in types
+    assert EntityType.ERROR_TYPE in types
+
+
+def test_build_entity_summaries_caps_top_entities_at_5(entity_data):
+    builder = InsightBuilder()
+    summaries = builder._build_entity_summaries(entity_data)
+
+    tool_summary = next(s for s in summaries if s.entity_type == EntityType.TOOL_NAME)
+    assert len(tool_summary.top_entities) <= 5
+
+
+def test_build_entity_summaries_total_unique(entity_data):
+    builder = InsightBuilder()
+    summaries = builder._build_entity_summaries(entity_data)
+
+    tool_summary = next(s for s in summaries if s.entity_type == EntityType.TOOL_NAME)
+    assert tool_summary.total_unique == 6  # all 6 entries, not capped for total
+
+
+# ---------------------------------------------------------------------------
+# MemoryExporterHook — on_session_end
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hook_does_nothing_when_exporter_none(session, analysis):
+    hook = MemoryExporterHook(exporter=None)
+    # Should not raise
+    await hook.on_session_end(session, events=[], checkpoints=[], analysis=analysis)
+
+
+@pytest.mark.asyncio
+async def test_hook_skips_export_when_not_completed(running_session, analysis):
+    exporter = AsyncMock()
+    hook = MemoryExporterHook(exporter=exporter, export_on_completion=True, export_on_update=False)
+
+    await hook.on_session_end(running_session, events=[], checkpoints=[], analysis=analysis)
+
+    exporter.export.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_hook_exports_when_completed(session, analysis):
+    exporter = AsyncMock()
+    hook = MemoryExporterHook(exporter=exporter, export_on_completion=True)
+
+    await hook.on_session_end(session, events=[], checkpoints=[], analysis=analysis)
+
+    exporter.export.assert_called_once()
+    call_arg = exporter.export.call_args[0][0]
+    assert isinstance(call_arg, TraceInsight)
+    assert call_arg.session_digest.session_id == session.id
+
+
+@pytest.mark.asyncio
+async def test_hook_exports_on_update_regardless_of_status(running_session, analysis):
+    exporter = AsyncMock()
+    hook = MemoryExporterHook(exporter=exporter, export_on_completion=False, export_on_update=True)
+
+    await hook.on_session_end(running_session, events=[], checkpoints=[], analysis=analysis)
+
+    exporter.export.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_hook_swallows_exporter_exceptions(session, analysis):
+    exporter = AsyncMock()
+    exporter.export.side_effect = RuntimeError("storage down")
+
+    hook = MemoryExporterHook(exporter=exporter, export_on_completion=True)
+
+    # Should not raise — exceptions are swallowed and logged
+    await hook.on_session_end(session, events=[], checkpoints=[], analysis=analysis)
+
+
+@pytest.mark.asyncio
+async def test_hook_logs_error_on_exception(session, analysis, caplog):
+    exporter = AsyncMock()
+    exporter.export.side_effect = ValueError("boom")
+
+    hook = MemoryExporterHook(exporter=exporter, export_on_completion=True)
+
+    with caplog.at_level(logging.ERROR):
+        await hook.on_session_end(session, events=[], checkpoints=[], analysis=analysis)
+
+    assert any("Failed to export" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# create_memory_exporter_hook
+# ---------------------------------------------------------------------------
+
+
+def test_create_memory_exporter_hook_returns_hook():
+    exporter = AsyncMock()
+    hook = create_memory_exporter_hook(exporter)
+
+    assert isinstance(hook, MemoryExporterHook)
+    assert hook.exporter is exporter
+
+
+def test_create_memory_exporter_hook_default_config():
+    hook = create_memory_exporter_hook()
+
+    assert hook.exporter is None
+    assert hook.export_on_completion is True
+    assert hook.export_on_update is False
+
+
+def test_create_memory_exporter_hook_custom_config():
+    hook = create_memory_exporter_hook(export_on_completion=False, export_on_update=True)
+
+    assert hook.export_on_completion is False
+    assert hook.export_on_update is True


### PR DESCRIPTION
## Summary

- Adds `tests/test_insight_builder.py` with 26 unit tests covering `InsightBuilder` and `MemoryExporterHook` (previously at zero coverage)
- `InsightBuilder`: covers `build_insight()`, `_build_session_digest()`, `_build_failure_patterns()`, `_build_entity_summaries()` including edge cases (None inputs, empty dicts, sort order, caps at 20/5)
- `MemoryExporterHook`: covers all conditional export paths (None exporter, non-completed skip, completion trigger, update trigger, exception swallowing, error logging), plus `create_memory_exporter_hook()` defaults and custom config

Closes #227

## Test plan

- [x] `python3 -m pytest -q tests/test_insight_builder.py` → 26 passed
- [x] `python3 -m pytest -q` (full suite) → 2780 passed, 27 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)