### PR TITLE
fix: TraceEvent.from_dict dict mutation and InsightBuilder failure timestamps

### DIFF
--- a/agent_debugger_sdk/core/events/base.py
+++ b/agent_debugger_sdk/core/events/base.py
@@ -142,6 +142,7 @@ class TraceEvent:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> TraceEvent:
         """Deserialize a dictionary to a TraceEvent."""
+        data = dict(data)
         # Handle timestamp deserialization
         if isinstance(data.get("timestamp"), str):
             data["timestamp"] = datetime.fromisoformat(data["timestamp"])

--- a/agent_debugger_sdk/core/exporters/insights.py
+++ b/agent_debugger_sdk/core/exporters/insights.py
@@ -114,12 +114,21 @@ class InsightBuilder:
                     if "error" in fingerprint.lower():
                         error_types.add(fingerprint.split(":")[0] if ":" in fingerprint else "RuntimeError")
 
+            cluster_timestamps = [
+                r["timestamp"]
+                for event_id in event_ids
+                if (r := rankings_by_id.get(event_id)) and r.get("timestamp")
+            ]
+            fallback_ts = ranking.get("timestamp", datetime.now(timezone.utc).isoformat())
+            first_seen_at = min(cluster_timestamps) if cluster_timestamps else fallback_ts
+            last_seen_at = max(cluster_timestamps) if cluster_timestamps else fallback_ts
+
             patterns.append(
                 FailurePattern(
                     fingerprint=cluster.get("fingerprint", ""),
                     count=cluster.get("count", 1),
-                    first_seen_at=ranking.get("timestamp", datetime.now(timezone.utc).isoformat()),
-                    last_seen_at=ranking.get("timestamp", datetime.now(timezone.utc).isoformat()),
+                    first_seen_at=first_seen_at,
+                    last_seen_at=last_seen_at,
                     sample_error_types=list(error_types)[:5],
                     representative_event_id=representative_id,
                     severity=ranking.get("severity", 0.5),


### PR DESCRIPTION
## Summary

- `TraceEvent.from_dict` (`agent_debugger_sdk/core/events/base.py`) now shallow-copies the input dict before mutation, preventing silent data corruption for callers that reuse the dict post-deserialization (replay, storage round-trips)
- `InsightBuilder._build_failure_patterns` (`agent_debugger_sdk/core/exporters/insights.py`) computes true `min`/`max` timestamps across all cluster events instead of assigning the representative event's timestamp to both `first_seen_at` and `last_seen_at`

Closes #247

## Test plan

- [ ] 42 existing targeted tests pass (`pytest -q tests/ -k "from_dict or failure_pattern or insight"`)
- [ ] Verify `TraceEvent.from_dict(d)` leaves `d` unchanged after call
- [ ] Verify `FailurePattern.first_seen_at < last_seen_at` when cluster spans multiple timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)