### PR TITLE
fix: TraceEvent.from_dict dict mutation and failure pattern timestamps

### DIFF
--- a/agent_debugger_sdk/core/events/base.py
+++ b/agent_debugger_sdk/core/events/base.py
@@ -142,6 +142,7 @@ class TraceEvent:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> TraceEvent:
         """Deserialize a dictionary to a TraceEvent."""
+        data = dict(data)
         # Handle timestamp deserialization
         if isinstance(data.get("timestamp"), str):
             data["timestamp"] = datetime.fromisoformat(data["timestamp"])

--- a/agent_debugger_sdk/core/exporters/insights.py
+++ b/agent_debugger_sdk/core/exporters/insights.py
@@ -114,12 +114,21 @@ class InsightBuilder:
                     if "error" in fingerprint.lower():
                         error_types.add(fingerprint.split(":")[0] if ":" in fingerprint else "RuntimeError")
 
+            cluster_timestamps = [
+                rankings_by_id[eid]["timestamp"]
+                for eid in event_ids
+                if eid in rankings_by_id and rankings_by_id[eid].get("timestamp")
+            ]
+            fallback_ts = ranking.get("timestamp", datetime.now(timezone.utc).isoformat())
+            first_seen = min(cluster_timestamps, default=fallback_ts)
+            last_seen = max(cluster_timestamps, default=fallback_ts)
+
             patterns.append(
                 FailurePattern(
                     fingerprint=cluster.get("fingerprint", ""),
                     count=cluster.get("count", 1),
-                    first_seen_at=ranking.get("timestamp", datetime.now(timezone.utc).isoformat()),
-                    last_seen_at=ranking.get("timestamp", datetime.now(timezone.utc).isoformat()),
+                    first_seen_at=first_seen,
+                    last_seen_at=last_seen,
                     sample_error_types=list(error_types)[:5],
                     representative_event_id=representative_id,
                     severity=ranking.get("severity", 0.5),


### PR DESCRIPTION
## Summary

- `TraceEvent.from_dict` (`agent_debugger_sdk/core/events/base.py`): adds `data = dict(data)` shallow copy before mutation — prevents silent corruption of caller's dict during replay/storage round-trips
- `InsightBuilder._build_failure_patterns` (`agent_debugger_sdk/core/exporters/insights.py`): computes `min`/`max` timestamps across all cluster `event_ids` for `first_seen_at`/`last_seen_at` — these were always identical before

Closes #247

## Test plan

- [x] `ruff check` passes on changed files
- [x] 51 tests pass (`python3 -m pytest -q`, 2 skipped for missing optional deps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)