### PR TITLE
fix: TraceEvent.from_dict dict mutation and failure pattern timestamps

### DIFF
--- a/agent_debugger_sdk/core/events/base.py
+++ b/agent_debugger_sdk/core/events/base.py
@@ -142,14 +142,11 @@ class TraceEvent:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> TraceEvent:
         """Deserialize a dictionary to a TraceEvent."""
-        # Handle timestamp deserialization
+        data = dict(data)
         if isinstance(data.get("timestamp"), str):
             data["timestamp"] = datetime.fromisoformat(data["timestamp"])
-
-        # Handle EventType deserialization
         if isinstance(data.get("event_type"), str):
             data["event_type"] = EventType(data["event_type"])
-
         return cls(**data)
 
     @classmethod

--- a/agent_debugger_sdk/core/exporters/insights.py
+++ b/agent_debugger_sdk/core/exporters/insights.py
@@ -106,20 +106,26 @@ class InsightBuilder:
             # Extract error types from events in this cluster
             event_ids = cluster.get("event_ids", [])
             error_types = set()
+            cluster_timestamps = []
             for event_id in event_ids[:10]:  # Limit to 10 events for performance
                 r = rankings_by_id.get(event_id, {})
+                if r.get("timestamp"):
+                    cluster_timestamps.append(r["timestamp"])
                 if "error" in r.get("fingerprint", "").lower():
-                    # Extract error type from fingerprint if available
                     fingerprint = r.get("fingerprint", "")
                     if "error" in fingerprint.lower():
                         error_types.add(fingerprint.split(":")[0] if ":" in fingerprint else "RuntimeError")
+
+            fallback_ts = datetime.now(timezone.utc).isoformat()
+            first_seen = min(cluster_timestamps) if cluster_timestamps else ranking.get("timestamp", fallback_ts)
+            last_seen = max(cluster_timestamps) if cluster_timestamps else ranking.get("timestamp", fallback_ts)
 
             patterns.append(
                 FailurePattern(
                     fingerprint=cluster.get("fingerprint", ""),
                     count=cluster.get("count", 1),
-                    first_seen_at=ranking.get("timestamp", datetime.now(timezone.utc).isoformat()),
-                    last_seen_at=ranking.get("timestamp", datetime.now(timezone.utc).isoformat()),
+                    first_seen_at=first_seen,
+                    last_seen_at=last_seen,
                     sample_error_types=list(error_types)[:5],
                     representative_event_id=representative_id,
                     severity=ranking.get("severity", 0.5),

--- a/tests/test_events_package.py
+++ b/tests/test_events_package.py
@@ -356,6 +356,27 @@ class TestEventSerialization:
         assert event.data == {"extra": "data"}
         assert event.importance == 0.8
 
+    def test_from_dict_does_not_mutate_caller_dict(self):
+        """from_dict must not modify the input dict — callers may reuse it."""
+        data = {
+            "id": "evt-999",
+            "session_id": "sess-1",
+            "event_type": "agent_start",
+            "timestamp": "2024-06-01T12:00:00+00:00",
+            "name": "",
+            "data": {},
+            "metadata": {},
+            "importance": 0.5,
+            "upstream_event_ids": [],
+        }
+        original_timestamp = data["timestamp"]
+        original_event_type = data["event_type"]
+
+        TraceEvent.from_dict(data)
+
+        assert data["timestamp"] == original_timestamp, "from_dict must not replace timestamp in caller's dict"
+        assert data["event_type"] == original_event_type, "from_dict must not replace event_type in caller's dict"
+
     def test_from_data_reconstructs_typed_event(self):
         """from_data should reconstruct typed events with their specific fields."""
         base_kwargs = {

--- a/tests/test_insight_builder.py
+++ b/tests/test_insight_builder.py
@@ -262,6 +262,31 @@ def test_build_failure_patterns_fingerprint_and_severity(builder):
     assert patterns[0].representative_event_id == "e1"
 
 
+def test_build_failure_patterns_first_and_last_seen_differ_across_cluster_events(builder):
+    analysis = {
+        "failure_clusters": [
+            {
+                "fingerprint": "fp-multi",
+                "count": 3,
+                "representative_event_id": "e2",
+                "event_ids": ["e1", "e2", "e3"],
+            }
+        ],
+        "event_rankings": [
+            {"event_id": "e1", "fingerprint": "fp-multi", "severity": 0.5, "timestamp": "2026-01-01T00:00:00Z"},
+            {"event_id": "e2", "fingerprint": "fp-multi", "severity": 0.6, "timestamp": "2026-01-02T00:00:00Z"},
+            {"event_id": "e3", "fingerprint": "fp-multi", "severity": 0.7, "timestamp": "2026-01-03T00:00:00Z"},
+        ],
+    }
+
+    patterns = builder._build_failure_patterns(analysis)
+
+    assert len(patterns) == 1
+    assert patterns[0].first_seen_at == "2026-01-01T00:00:00Z"
+    assert patterns[0].last_seen_at == "2026-01-03T00:00:00Z"
+    assert patterns[0].first_seen_at != patterns[0].last_seen_at
+
+
 # ---------------------------------------------------------------------------
 # InsightBuilder._build_entity_summaries
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #247.

- `TraceEvent.from_dict` no longer mutates caller's input dict.
- `InsightBuilder` failure patterns compute first/last_seen from full cluster timestamps (min/max), fallback when missing.
- Adds 2 tests (70 affected tests pass; ruff clean).

Supersedes #248 and #249 (same fix, this one includes tests).

Co-Authored-By: Claude <noreply@anthropic.com>