### PR TITLE
docs: fix broken cross-references after docs restructure

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,8 +4,8 @@
 > planning phase and no longer reflects the actual codebase structure.  For
 > current implementation details, see:
 >
-> - [docs/architecture.md](./docs/architecture.md)
-> - [docs/how-it-works.md](./docs/how-it-works.md)
+> - [docs/guides/architecture.md](./docs/guides/architecture.md)
+> - [docs/guides/how-it-works.md](./docs/guides/how-it-works.md)
 > - [CLAUDE.md](./CLAUDE.md) (repo map section)
 >
 > The file maps and code examples below are retained for historical context
@@ -28,9 +28,9 @@ As of `2026-03-23`, the most important current-state corrections are:
 
 For implementation truth, prefer:
 
-- [docs/progress.md](./docs/progress.md)
-- [docs/architecture.md](./docs/architecture.md)
-- [docs/improvement-roadmap.md](./docs/improvement-roadmap.md)
+- [docs/guides/progress.md](./docs/guides/progress.md)
+- [docs/guides/architecture.md](./docs/guides/architecture.md)
+- [docs/plans/improvement-roadmap.md](./docs/plans/improvement-roadmap.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -351,11 +351,11 @@ Peaky Peek is informed by research on agent debugging, causal tracing, failure a
 
 ## Documentation
 
-- [5-Minute Getting Started](./docs/getting-started.md)
-- [Integration Guide](./docs/integration.md)
-- [SDK README](./SDK_README.md)
+- [5-Minute Getting Started](./docs/guides/getting-started.md)
+- [Integration Guide](./docs/guides/integration.md)
+- [SDK README](./agent_debugger_sdk/README.md)
 - [Architecture Overview](./ARCHITECTURE.md)
-- [Progress Tracker](./docs/progress.md)
+- [Progress Tracker](./docs/guides/progress.md)
 
 ---
 

--- a/docs/guides/LEARNING.md
+++ b/docs/guides/LEARNING.md
@@ -1,6 +1,6 @@
 # Learning Guide
 
-The detailed learning-oriented documentation lives under [`docs/`](./docs/README.md), but the shortest useful summary is:
+The detailed learning-oriented documentation lives under [`docs/`](../README.md), but the shortest useful summary is:
 
 ## What This Repo Has Taught So Far
 
@@ -15,10 +15,10 @@ The detailed learning-oriented documentation lives under [`docs/`](./docs/README
 
 ## Best Starting Points
 
-- [Progress](./docs/progress.md)
-- [How It Works](./docs/how-it-works.md)
-- [Architecture](./docs/architecture.md)
-- [Repo Overview](./docs/repo-overview.md)
-- [Lessons Learned](./docs/lessons-learned.md)
-- [Improvement Roadmap](./docs/improvement-roadmap.md)
-- [Research Inspiration](./docs/research-inspiration.md)
+- [Progress](./progress.md)
+- [How It Works](./how-it-works.md)
+- [Architecture](./architecture.md)
+- [Repo Overview](./repo-overview.md)
+- [Lessons Learned](./lessons-learned.md)
+- [Improvement Roadmap](../plans/improvement-roadmap.md)
+- [Research Inspiration](../research/research-inspiration.md)

--- a/docs/guides/progress.md
+++ b/docs/guides/progress.md
@@ -23,7 +23,7 @@ Snapshot date: `2026-03-24`
 | Bundled UI | Implemented | Frontend built to `frontend/dist/`, served at `/ui/` by FastAPI when present. |
 | JSON export | Implemented | `GET /api/sessions/{id}/export` returns portable session bundle (session + events + checkpoints). |
 | Examples | Implemented | 8 annotated examples in `examples/` covering hello world, research agent, LangChain, PydanticAI, checkpoint replay, safety audit, loop detection, and live streaming. |
-| Getting started guide | Implemented | `docs/getting-started.md` covers install, start, first trace, UI tour, and export in 5 minutes. |
+| Getting started guide | Implemented | `docs/guides/getting-started.md` covers install, start, first trace, UI tour, and export in 5 minutes. |
 | Replay depth L1 | Implemented | Typed checkpoint schemas: `BaseCheckpointState`, `LangChainCheckpointState`, `CustomCheckpointState` with validation and serialization helpers. |
 | Replay depth L2 | Implemented | `TraceContext.restore()` classmethod fetches checkpoint from server and creates a new context with restored state. REST endpoints: `GET /api/checkpoints/{id}` and `POST /api/checkpoints/{id}/restore`. |
 


### PR DESCRIPTION
## What & Why

The doc-restructuring commits (`5b9b310` docs restructure, `d01f348` reduce root clutter) moved:

- guides → `docs/guides/`
- SDK README → `agent_debugger_sdk/README.md`
- roadmap → `docs/plans/improvement-roadmap.md`
- research notes → `docs/research/`

…but left cross-references in four files pointing at the old, now-missing paths. Every one of these links 404s.

`ARCHITECTURE.md` is explicitly **deprecated** and its *only* remaining purpose is a banner redirecting readers to the current docs — so the entire banner was broken.

## Changes

| File | Fix |
|------|-----|
| `README.md` | 4 links in the Documentation section repointed (incl. dead `SDK_README.md` → `agent_debugger_sdk/README.md`) |
| `ARCHITECTURE.md` | 5 links in the deprecation banner + reality-check section repointed |
| `docs/guides/LEARNING.md` | 8 links fixed with correct relative paths from `docs/guides/` |
| `docs/guides/progress.md` | 1 stale path in the status table |

Content unchanged — link/path text only. Each target verified to exist on disk.

## Verification

- All 16 repointed targets confirmed present.
- No remaining `./docs/<name>.md` / `./SDK_README.md` references in the 4 files.
- Docs-only change; no code/tests touched.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>