### PR TITLE
docs: repoint broken cross-refs in docs/README.md and SDK README

### DIFF
--- a/agent_debugger_sdk/README.md
+++ b/agent_debugger_sdk/README.md
@@ -148,9 +148,9 @@ Important:
 
 ## More Docs
 
-- [Intro](./docs/intro.md)
-- [Integration](./docs/integration.md)
-- [Progress](./docs/progress.md)
+- [Intro](../docs/guides/intro.md)
+- [Integration](../docs/guides/integration.md)
+- [Progress](../docs/guides/progress.md)
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,20 +4,20 @@ This folder explains what the project is, how to integrate it, and how it works.
 
 ## Start Here
 
-- [Intro](./intro.md): the plain-language explanation of the product
-- [Integration](./integration.md): how to instrument your code locally
-- [Progress](./progress.md): current implementation status
-- [How It Works](./how-it-works.md): the runtime flow from trace capture to UI
-- [Architecture](./architecture.md): system layers, modules, and data flow
-- [Repo Overview](./repo-overview.md): what is in the repository
+- [Intro](./guides/intro.md): the plain-language explanation of the product
+- [Integration](./guides/integration.md): how to instrument your code locally
+- [Progress](./guides/progress.md): current implementation status
+- [How It Works](./guides/how-it-works.md): the runtime flow from trace capture to UI
+- [Architecture](./guides/architecture.md): system layers, modules, and data flow
+- [Repo Overview](./guides/repo-overview.md): what is in the repository
 
 ## Reference
 
-- [Lessons Learned](./lessons-learned.md): what building the debugger so far has taught
-- [Console Workflows](./console-workflows.md): the debugger workflows implemented in the UI
-- [Improvement Roadmap](./improvement-roadmap.md): useful next improvements
-- [Research Implementation Plan](./research-implementation-plan.md): how paper-inspired features should be built
-- [Research Inspiration](./research-inspiration.md): papers influencing the design direction
+- [Lessons Learned](./guides/lessons-learned.md): what building the debugger so far has taught
+- [Console Workflows](./guides/console-workflows.md): the debugger workflows implemented in the UI
+- [Improvement Roadmap](./plans/improvement-roadmap.md): useful next improvements
+- [Research Implementation Plan](./research/research-implementation-plan.md): how paper-inspired features should be built
+- [Research Inspiration](./research/research-inspiration.md): papers influencing the design direction
 - [Paper Notes](./papers/README.md): notes on specific papers
 - [ADRs](./decisions/README.md): architecture decision records
 


### PR DESCRIPTION
## What

The docs restructure moved guides to `docs/guides/`, the roadmap to `docs/plans/`, and research notes to `docs/research/` — but the two primary documentation entry points still pointed at the old flat `docs/*.md` paths. Every one of these 14 links resolved to a non-existent file.

## Changes

- **`docs/README.md`** (index): repointed 11 links to their current locations — `./guides/*`, `./plans/*`, `./research/*`. The `./papers/README.md` and `./decisions/README.md` links already resolved correctly and were left untouched.
- **`agent_debugger_sdk/README.md`** ("More Docs" section): repointed 3 links from the non-existent `./docs/*.md` to `../docs/guides/*` (the SDK README lives in `agent_debugger_sdk/`, so the repo `docs/` tree is one level up).

## Verification

- Each new target verified to exist on disk before repointing.
- Re-ran a markdown link auditor over both files after the edit → 0 broken links.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>