### PR TITLE
docs: repoint broken cross-refs in guides/research/decisions/RELEASE tail

### DIFF
--- a/docs/RELEASE/0.1.4.md
+++ b/docs/RELEASE/0.1.4.md
@@ -8,7 +8,7 @@ The main issue: `pyproject.toml` still shows `0.1.2`, but `0.1.3` on PyPI is ahe
  local version with the remote.
 - **Issue**: The `pyproject.toml` has `0.1.3`, which is should be treated as outdated
 - **Solution**: Bump versions to `0.1.4` or `0.1.5` (new release with improvements)
-- Better message: "See [ top 0.1% strategy](./docs/TOP_0.1_PERCENT_STRATEGY.md) for details on positioning"
+- Better message: "See [ top 0.1% strategy](../plans/TOP_0.1_PERCENT_STRATEGY.md) for details on positioning"
 
 - **Wait**: If tests fail again, consider holding off, see "fix first, check later"
 - **Otherwise**: Wait for v0.1.5 with meaningful features before releasing**

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -39,4 +39,4 @@ As of `2026-03-23`, the accepted ADRs are at different implementation stages:
 - **ADR-008**: partially implemented. API key helpers, auth models, and redaction modules exist, but tenant enforcement and write-path integration are still pending.
 - **ADR-011**: partially underway. The local debugger, benchmark seeds, and docs structure are strong; cloud-hardening work has started but is not complete.
 
-Read [`../progress.md`](../progress.md) for the implementation snapshot that complements these decisions.
+Read [`../guides/progress.md`](../guides/progress.md) for the implementation snapshot that complements these decisions.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -65,4 +65,4 @@ Peaky Peek automatically captures all LLM calls and tool use.
 
 - [How It Works](./how-it-works.md)
 - [Architecture](./architecture.md)
-- [Examples](../examples/)
+- [Examples](../../examples/)

--- a/docs/guides/progress.md
+++ b/docs/guides/progress.md
@@ -104,7 +104,7 @@ Planned in `docs/improvement-roadmap.md`:
 
 ## Decision Progress
 
-The ADR set in [`docs/decisions/`](./decisions/README.md) is visible in code:
+The ADR set in [`docs/decisions/`](../decisions/README.md) is visible in code:
 
 - ADR-006 is visible through `init()` and env-based configuration.
 - ADR-008 is visible through API key helpers, auth models, and the redaction pipeline, with tenant isolation enforced in the repository.

--- a/docs/research/research-implementation-plan.md
+++ b/docs/research/research-implementation-plan.md
@@ -40,9 +40,9 @@ This page is intentionally research-feature focused.
 
 For the current platform and cloud-readiness state, use:
 
-- [Progress](./progress.md)
-- [Architecture](./architecture.md)
-- [Improvement Roadmap](./improvement-roadmap.md)
+- [Progress](../guides/progress.md)
+- [Architecture](../guides/architecture.md)
+- [Improvement Roadmap](../plans/improvement-roadmap.md)
 
 ## Research Themes To Implement
 

--- a/docs/research/research-inspiration.md
+++ b/docs/research/research-inspiration.md
@@ -34,7 +34,7 @@ These papers are here because they push on the same problems this project is try
 - [FailureMem: A Failure-Aware Multimodal Framework for Autonomous Software Repair](https://arxiv.org/abs/2603.17826)
   Why it matters here: learning from failed repair attempts instead of treating them as disposable noise.
 
-For repo-oriented notes on each paper, see [Paper Notes](./papers/README.md).
+For repo-oriented notes on each paper, see [Paper Notes](../papers/README.md).
 
 ## How To Use These Papers In This Repo
 


### PR DESCRIPTION
Continuation of the docs-restructure link cleanup (#263, #264).

## What

Fixes **8 broken relative links** left across 6 files by the docs restructure (move of guides to `docs/guides/`, roadmap to `docs/plans/`, paper notes to `docs/papers/`):

| File | Fix |
|---|---|
| `docs/RELEASE/0.1.4.md` | strategy ref `./docs/TOP_0.1_PERCENT_STRATEGY.md` → `../plans/` |
| `docs/decisions/README.md` | progress ref `../progress.md` → `../guides/progress.md` (label + href, both stale) |
| `docs/guides/progress.md` | ADR link `./decisions/README.md` → `../decisions/README.md` |
| `docs/guides/getting-started.md` | Examples `../examples/` → `../../examples/` (root `examples/` is two levels up) |
| `docs/research/research-implementation-plan.md` | progress/architecture/roadmap refs → `../guides/*` and `../plans/*` |
| `docs/research/research-inspiration.md` | Paper Notes `./papers/` → `../papers/` |

## Verification

All 8 targets verified to exist on disk. A repo-wide markdown link auditor confirms these 8 are resolved.

## Out of scope

Remaining broken links are a **separate defect class** and intentionally excluded:
- Never-recorded demo GIF placeholders (`docs/demo/RECORDING_GUIDE.md`, `docs/plans/TOP_0.1_PERCENT_STRATEGY.md`, `docs/reports/QUICK_WINS_THIS_WEEK.md`) — the GIFs were never created; repointing requires choosing a real asset (judgment call).
- The vendored `docs-site/` mkdocs tree — separate maintenance boundary.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)