### PR TITLE
chore(frontend): remove 3 dead memoized panel exports

### DIFF
--- a/frontend/src/components/BackwardFailureAttributionPanel.tsx
+++ b/frontend/src/components/BackwardFailureAttributionPanel.tsx
@@ -1,5 +1,5 @@
 import type { TraceEvent, FailureExplanation } from '../types'
-import { memo, useState } from 'react'
+import { useState } from 'react'
 
 interface BackwardFailureAttributionPanelProps {
   events: TraceEvent[]
@@ -340,17 +340,3 @@ export function BackwardFailureAttributionPanel({
     </section>
   )
 }
-
-// Custom comparison for BackwardFailureAttributionPanel
-function arePropsEqual(
-  prevProps: Readonly<BackwardFailureAttributionPanelProps>,
-  nextProps: Readonly<BackwardFailureAttributionPanelProps>
-): boolean {
-  return (
-    prevProps.events === nextProps.events &&
-    prevProps.failureExplanations === nextProps.failureExplanations &&
-    prevProps.selectedEventId === nextProps.selectedEventId
-  )
-}
-
-export const BackwardFailureAttributionPanelMemo = memo(BackwardFailureAttributionPanel, arePropsEqual)

--- a/frontend/src/components/ConformalPredictionScoringPanel.tsx
+++ b/frontend/src/components/ConformalPredictionScoringPanel.tsx
@@ -1,5 +1,4 @@
 import type { TraceEvent } from '../types'
-import { memo } from 'react'
 
 interface ConformalPredictionScoringPanelProps {
   events: TraceEvent[]
@@ -407,16 +406,3 @@ export function ConformalPredictionScoringPanel({
     </section>
   )
 }
-
-// Custom comparison for ConformalPredictionScoringPanel
-function arePropsEqual(
-  prevProps: Readonly<ConformalPredictionScoringPanelProps>,
-  nextProps: Readonly<ConformalPredictionScoringPanelProps>
-): boolean {
-  return (
-    prevProps.events === nextProps.events &&
-    prevProps.selectedEventId === nextProps.selectedEventId
-  )
-}
-
-export const ConformalPredictionScoringPanelMemo = memo(ConformalPredictionScoringPanel, arePropsEqual)

--- a/frontend/src/components/FrameLifetimeTracePanel.tsx
+++ b/frontend/src/components/FrameLifetimeTracePanel.tsx
@@ -1,5 +1,4 @@
 import type { TraceEvent } from '../types'
-import { memo } from 'react'
 
 interface FrameLifetimeTracePanelProps {
   events: TraceEvent[]
@@ -243,16 +242,3 @@ export function FrameLifetimeTracePanel({
     </section>
   )
 }
-
-// Custom comparison for FrameLifetimeTracePanel
-function arePropsEqual(
-  prevProps: Readonly<FrameLifetimeTracePanelProps>,
-  nextProps: Readonly<FrameLifetimeTracePanelProps>
-): boolean {
-  return (
-    prevProps.events === nextProps.events &&
-    prevProps.selectedEventId === nextProps.selectedEventId
-  )
-}
-
-export const FrameLifetimeTracePanelMemo = memo(FrameLifetimeTracePanel, arePropsEqual)


### PR DESCRIPTION
Removes three exported-but-never-imported memoized panel wrappers identified by `ts-prune` and confirmed by a repo-wide grep (each `*Memo` export has exactly one reference: its own definition).

**Removed per file:**
- `BackwardFailureAttributionPanelMemo` (BackwardFailureAttributionPanel.tsx)
- `ConformalPredictionScoringPanelMemo` (ConformalPredictionScoringPanel.tsx)
- `FrameLifetimeTracePanelMemo` (FrameLifetimeTracePanel.tsx)

Each wrapper carried a now-orphaned `memo` import and a private `arePropsEqual` custom-compare helper used only by the dead export, so those were removed too. The base panel components are untouched (still exported).

**Why:** dead code. The memoized variants were never wired into the app. The frontend is a private (`private: true`) app bundle, not a published package, so these exports have no external consumers.

**Validation:**
- `npx eslint .` → 0 errors / 0 warnings
- `tsc && vite build` → green (646 modules)

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>