### PR TITLE
docs(docs-site): fix 3 broken links in published mkdocs site

### DIFF
--- a/docs-site/docs/contributing.md
+++ b/docs-site/docs/contributing.md
@@ -247,7 +247,7 @@ Use [GitHub Issues](https://github.com/acailic/agent_debugger/issues) with:
 
 ## Design Philosophy
 
-From [`CLAUDE.md`](../CLAUDE.md):
+From [`CLAUDE.md`](https://github.com/acailic/agent_debugger/blob/main/CLAUDE.md):
 
 - **Ruthless simplicity** — Every abstraction must justify itself
 - **Start minimal** — Keep the core path coherent before adding depth
@@ -262,7 +262,7 @@ From [`CLAUDE.md`](../CLAUDE.md):
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the [MIT License](../LICENSE).
+By contributing, you agree that your contributions will be licensed under the [MIT License](https://github.com/acailic/agent_debugger/blob/main/LICENSE).
 
 ## Code of Conduct
 

--- a/docs-site/docs/getting-started.md
+++ b/docs-site/docs/getting-started.md
@@ -146,7 +146,7 @@ adapter = PydanticAIAdapter(agent, agent_name="support_agent")
 
 ## Next Steps
 
-- [How It Works](../docs/how-it-works.md) — Understanding the system architecture
+- [How It Works](architecture.md) — Understanding the system architecture
 - [Installation](installation.md) — Detailed installation options
 - [Integrations](integrations.md) — Framework-specific setup guides
 - [Configuration](configuration.md) — Environment variables and settings


### PR DESCRIPTION
Fixes 3 broken relative links in the published GitHub Pages docs site (docs-site/docs/), the last unmaintained boundary from the docs restructure tail.

## Changes

- **getting-started.md** `[How It Works](../docs/how-it-works.md)` → `architecture.md`. The doubly-broken `../docs/how-it-works.md` target never existed; `architecture.md` is the system-architecture page already linked as "System design overview" in `index.md:103` and `contributing.md:280`.
- **contributing.md** `CLAUDE.md` and `LICENSE` links pointed at `../` (i.e. `docs-site/`) where neither file exists. Both are repo-root files outside the mkdocs `docs_dir`, so they cannot be served by the site at any relative path. Repointed to absolute `github.com/.../blob/main/` URLs, matching the existing issues/discussions linking pattern in the same file.

## Verification

Repo-relative link auditor scoped to `docs-site/` reports 0 broken links after the fix (was 3).

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>