### PR TITLE
chore: modernize deprecated typing/error aliases (UP024/UP035)

### DIFF
--- a/agent_debugger_sdk/core/frame_tracer.py
+++ b/agent_debugger_sdk/core/frame_tracer.py
@@ -11,8 +11,9 @@ import functools
 import inspect
 import time
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Callable
+from typing import Any
 
 
 @dataclass(kw_only=True)

--- a/agent_debugger_sdk/transport.py
+++ b/agent_debugger_sdk/transport.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Callable
+from collections.abc import Callable
 
 import httpx
 

--- a/api/middleware.py
+++ b/api/middleware.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import logging
 import uuid
+from collections.abc import Callable
 from time import perf_counter
-from typing import Callable
 
 from fastapi import Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware

--- a/scripts/hooks/check_security.py
+++ b/scripts/hooks/check_security.py
@@ -144,7 +144,7 @@ def main() -> None:
                 reason += f" (and {len(issues) - 3} more)"
             print(json.dumps({"decision": "deny", "reason": reason}))
 
-    except (OSError, IOError):
+    except OSError:
         # On read errors, allow the operation
         print('{"decision":"allow"}')
         return


### PR DESCRIPTION
## Summary

Modernize 4 deprecated stdlib aliases flagged by ruff `UP024`/`UP035`:

- `typing.Callable` → `collections.abc.Callable` (3 files: `frame_tracer.py`, `transport.py`, `middleware.py`) — `typing.Callable` deprecated since Python 3.9, `collections.abc` is the canonical source.
- `except (OSError, IOError)` → `except OSError` (`scripts/hooks/check_security.py`) — `IOError` has been an alias for `OSError` since Python 3.0; the tuple was redundant.

No runtime behavior change on Python 3.10+.

## Validation

- `ruff check .` clean (0 errors)
- Full pytest suite: **2891 passed, 19 skipped, 0 warnings** (140s)
- Targeted tests on transport/middleware/frame/security areas: green

## Notes

Investigated the larger `RUF100` (unused `noqa`) surface first but found it unsafe in this repo: running `ruff --select RUF100` evaluates noqa in isolation and mis-flags every `# noqa: F401` (importability checks) and `# noqa: E402` (intentional late imports) as unused — removing them exposes 26 real violations. Those noqa are all legitimate. Scoped this PR to the genuinely-safe `UP024`/`UP035` modernizations only.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>