### PR TITLE
chore: use raise...from for explicit exception chaining (B904)

### DIFF
--- a/api/reasoning_routes.py
+++ b/api/reasoning_routes.py
@@ -137,7 +137,7 @@ async def edit_reasoning(
         raise HTTPException(
             status_code=400,
             detail=f"Invalid operation: {edit_request.operation}. Must be one of: modify, insert, delete, replace"
-        )
+        ) from None
 
     try:
         edit = editor.edit_reasoning(
@@ -148,7 +148,7 @@ async def edit_reasoning(
             position=edit_request.position,
         )
     except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e))
+        raise HTTPException(status_code=404, detail=str(e)) from e
 
     return {
         "session_id": session_id,
@@ -193,7 +193,7 @@ async def create_scenario_branch(
             raise HTTPException(
                 status_code=400,
                 detail=f"Invalid operation: {edit_request.operation}"
-            )
+            ) from None
 
         # Get old value
         event = editor.get_event_by_id(edit_request.event_id)
@@ -266,7 +266,7 @@ async def get_replay_events(
             branch_id=branch_id,
         )
     except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e))
+        raise HTTPException(status_code=404, detail=str(e)) from e
 
     return {
         "session_id": session_id,
@@ -451,7 +451,7 @@ async def export_scenario(
     try:
         exported = editor.export_scenario(branch_id)
     except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e))
+        raise HTTPException(status_code=404, detail=str(e)) from e
 
     return {
         "session_id": session_id,
@@ -486,7 +486,7 @@ async def import_scenario(
     try:
         imported_branch = editor.import_scenario(scenario_data)
     except (ValueError, KeyError) as e:
-        raise HTTPException(status_code=400, detail=f"Invalid scenario data: {str(e)}")
+        raise HTTPException(status_code=400, detail=f"Invalid scenario data: {str(e)}") from e
 
     return {
         "session_id": session_id,

--- a/api/search_routes.py
+++ b/api/search_routes.py
@@ -172,13 +172,13 @@ async def search_sessions_nl(
             started_after = datetime.fromisoformat(request.started_after.replace("Z", "+00:00"))
             filters_applied["started_after"] = request.started_after
         except ValueError as e:
-            raise ValueError(f"Invalid started_after datetime '{request.started_after}': {e}")
+            raise ValueError(f"Invalid started_after datetime '{request.started_after}': {e}") from e
     if request.started_before:
         try:
             started_before = datetime.fromisoformat(request.started_before.replace("Z", "+00:00"))
             filters_applied["started_before"] = request.started_before
         except ValueError as e:
-            raise ValueError(f"Invalid started_before datetime '{request.started_before}': {e}")
+            raise ValueError(f"Invalid started_before datetime '{request.started_before}': {e}") from e
 
     # Perform search with all filters
     sessions = await repo.search_sessions(

--- a/collector/server.py
+++ b/collector/server.py
@@ -220,7 +220,7 @@ def _parse_event_type(event_type_str: str) -> EventType:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Invalid event_type. Must be one of: {valid_types}",
-        )
+        ) from None
 
 
 def _parse_timestamp(timestamp: str | None) -> datetime | None:


### PR DESCRIPTION
## Summary

Add explicit exception chaining to 9 `raise` statements inside `except` blocks flagged by ruff **B904**.

ruff B904 requires `raise ... from err` or `raise ... from None` to make exception-handling intent explicit and avoid masking the original cause. The project's lint config (E/F/I) does not include B904, so these were surfaced via a targeted `--select B904` pass.

## Changes (3 files, 9 sites)

- **`from None`** where the caught exception's message is discarded and replaced with a fresh detail string (bare `except ValueError:` blocks in `reasoning_routes.py` x2 and `collector/server.py` x1)
- **`from e`** where the original message is preserved via `str(e)` in the HTTP detail or re-raised (`reasoning_routes.py` x4, `search_routes.py` x2)

Files:
- `api/reasoning_routes.py` — 6 sites
- `api/search_routes.py` — 2 sites (re-raised `ValueError`)
- `collector/server.py` — 1 site

## Rationale per site

| Pattern | Choice | Reason |
|---|---|---|
| `except ValueError as e: raise HTTPException(detail=str(e))` | `from e` | message preserved; keep causal chain for debugging |
| `except ValueError as e: raise ValueError(f"...{e}")` | `from e` | re-raise; preserve parse-error chain |
| `except ValueError: raise HTTPException(detail=f"...")` | `from None` | original discarded; fresh user-facing message |

## Validation

- `ruff check --select B904 .` → 9 → 0
- `ruff check .` → clean (E/F/I config)
- `pytest -q -k "reasoning or search or collector"` → 401 passed, 1 skipped (redis not installed, unrelated)

Zero runtime-behavior change: exception chaining only affects the `__cause__`/`__context__` attributes and traceback presentation, not control flow or HTTP status codes.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>