### PR TITLE
chore: simplify redundant comprehensions and drop placeholder pass (C4/PIE790)

### DIFF
--- a/agent_debugger_sdk/adapters/tests/test_langchain/__init__.py
+++ b/agent_debugger_sdk/adapters/tests/test_langchain/__init__.py
@@ -35,7 +35,6 @@ class TestLangChainTracingHandler(
 ):
     """Combined test class for backward compatibility."""
 
-    pass
 
 
 __all__ = [

--- a/agent_debugger_sdk/core/context/session_manager.py
+++ b/agent_debugger_sdk/core/context/session_manager.py
@@ -18,7 +18,6 @@ from agent_debugger_sdk.core.events import Session, SessionStatus
 class _CheckpointRestoreError(Exception):
     """Raised when checkpoint restoration fails."""
 
-    pass
 
 
 def _resolve_restore_server_url(server_url: str | None) -> str:

--- a/agent_debugger_sdk/core/exporters/insights.py
+++ b/agent_debugger_sdk/core/exporters/insights.py
@@ -30,7 +30,6 @@ class InsightBuilder:
 
     def __init__(self):
         """Initialize the insight builder."""
-        pass
 
     def build_insight(
         self,

--- a/agent_debugger_sdk/core/violation_detector.py
+++ b/agent_debugger_sdk/core/violation_detector.py
@@ -635,7 +635,7 @@ class SparseFailureDetector:
         for pattern_key, occurrences in error_patterns.items():
             if len(occurrences) >= min_occurrences:
                 # Get unique session IDs
-                session_ids = list(set(sid for sid, _ in occurrences))
+                session_ids = list({sid for sid, _ in occurrences})
 
                 if len(session_ids) >= min_occurrences:
                     pattern = SparseFailurePattern(

--- a/agent_debugger_sdk/transport.py
+++ b/agent_debugger_sdk/transport.py
@@ -28,13 +28,11 @@ class TransportError(Exception):
 class TransientError(TransportError):
     """Error that may be resolved by retrying (e.g., network timeout, 5xx)."""
 
-    pass
 
 
 class PermanentError(TransportError):
     """Error that will not be resolved by retrying (e.g., 4xx auth failure)."""
 
-    pass
 
 
 DeliveryFailureCallback = Callable[[TransportError], None]

--- a/api/services.py
+++ b/api/services.py
@@ -138,7 +138,7 @@ def compute_dict_delta(
         return current or {}
 
     if not current:
-        return {k: None for k in (previous or {})}
+        return dict.fromkeys(previous or {})
 
     all_keys = set(previous.keys()) | set(current.keys())
     delta: dict[str, Any] = {}

--- a/collector/failure_memory.py
+++ b/collector/failure_memory.py
@@ -9,7 +9,6 @@ from typing import Any
 class EmbeddingGenerationError(Exception):
     """Raised when embedding generation fails."""
 
-    pass
 
 
 @dataclass

--- a/collector/patterns/health_report.py
+++ b/collector/patterns/health_report.py
@@ -110,7 +110,7 @@ def generate_health_report(
     health_score = max(0.0, health_score)
 
     # Generate agent summary
-    affected_agents = list(set(p.agent_name for p in patterns))
+    affected_agents = list({p.agent_name for p in patterns})
     critical_count = patterns_by_severity["critical"]
     warning_count = patterns_by_severity["warning"]
 
@@ -331,7 +331,7 @@ def _calculate_trend_metrics(
 
     metrics["avg_error_rate_change"] = sum(error_trends) / len(error_trends) if error_trends else 0.0
     metrics["avg_tool_failure_change"] = sum(tool_failures) / len(tool_failures) if tool_failures else 0.0
-    metrics["agents_with_issues"] = len(set(p.agent_name for p in patterns))
+    metrics["agents_with_issues"] = len({p.agent_name for p in patterns})
     metrics["total_affected_sessions"] = sum(len(p.affected_sessions) for p in patterns)
 
     return metrics

--- a/scripts/hooks/check_duplicate_queries.py
+++ b/scripts/hooks/check_duplicate_queries.py
@@ -55,7 +55,7 @@ def extract_query_shapes(content: str) -> list[str]:
             where_clause = where_match.group(1)
             conditions = re.findall(r"(\w+)\.(\w+)\s*==", where_clause)
             if conditions:
-                cond_names = sorted(set([c[1] for c in conditions]))
+                cond_names = sorted({c[1] for c in conditions})
                 shapes.append(f"{model}.where[{', '.join(cond_names)}]")
     return shapes
 

--- a/storage/models.py
+++ b/storage/models.py
@@ -14,7 +14,6 @@ from agent_debugger_sdk.core.events import SessionStatus
 class Base(DeclarativeBase):
     """Base class for all ORM models."""
 
-    pass
 
 
 class SessionModel(Base):

--- a/storage/repositories/alert_repo.py
+++ b/storage/repositories/alert_repo.py
@@ -405,7 +405,7 @@ class AnomalyAlertRepository:
             .where(AnomalyAlertModel.tenant_id == self.tenant_id)
             .group_by(AnomalyAlertModel.status)
         )
-        by_status = {status: count for status, count in status_result.all()}
+        by_status = dict(status_result.all())
 
         # Count by alert_type
         type_result = await self.session.execute(
@@ -413,7 +413,7 @@ class AnomalyAlertRepository:
             .where(AnomalyAlertModel.tenant_id == self.tenant_id)
             .group_by(AnomalyAlertModel.alert_type)
         )
-        by_type = {alert_type: count for alert_type, count in type_result.all()}
+        by_type = dict(type_result.all())
 
         # Count by severity ranges
         critical_result = await self.session.execute(

--- a/tests/research/test_research_features.py
+++ b/tests/research/test_research_features.py
@@ -724,7 +724,7 @@ class TestScoreSession:
         assert len(scores) == len(events)
 
         contributions = {s.contribution for s in scores}
-        assert contributions.issubset({c for c in StepContribution})
+        assert contributions.issubset(set(StepContribution))
 
     def test_error_at_step_marks_harmful(self) -> None:
         from agent_debugger_sdk.core.redundancy_scorer import StepContribution, score_session

--- a/tests/research/test_research_workflows.py
+++ b/tests/research/test_research_workflows.py
@@ -10,7 +10,6 @@ import pytest
 # instances that would otherwise try to connect to localhost:8000).
 async def _noop_persist(event):  # noqa: ARG001
     """No-op persister to prevent HTTP transport creation."""
-    pass
 
 
 from agent_debugger_sdk.core.context import configure_event_pipeline  # noqa: E402

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -17,7 +17,6 @@ import pytest
 # the HTTP transport branch entirely — no env var needed.
 async def _noop_persist(event):  # noqa: ARG001
     """No-op persister to prevent HTTP transport creation in benchmark tests."""
-    pass
 
 
 from agent_debugger_sdk.core.context import configure_event_pipeline  # noqa: E402

--- a/tests/test_feature_1_why_button.py
+++ b/tests/test_feature_1_why_button.py
@@ -23,13 +23,11 @@ import collector.causal_analysis as _causal_analysis  # noqa: F401
 class EventNotFoundError(Exception):
     """Raised when an event ID cannot be found in the system."""
 
-    pass
 
 
 class InvalidEventDataError(Exception):
     """Raised when event data is malformed or invalid."""
 
-    pass
 
 
 # =============================================================================

--- a/tests/test_reasoning_routes.py
+++ b/tests/test_reasoning_routes.py
@@ -92,17 +92,14 @@ class TestReasoningRoutesIntegration:
         """Test the edit reasoning endpoint."""
         # This is a placeholder for actual integration testing
         # In real testing, we'd use dependency overrides to inject the mock repository
-        pass
 
     def test_create_scenario_branch_endpoint(self, test_client, mock_repository):
         """Test the create scenario branch endpoint."""
         # Placeholder for integration testing
-        pass
 
     def test_get_replay_events_endpoint(self, test_client, mock_repository):
         """Test the get replay events endpoint."""
         # Placeholder for integration testing
-        pass
 
 
 class TestReasoningRoutesUnit:


### PR DESCRIPTION
## Summary

Continues the ruff modernization series (#272 UP024/UP035, #273 UP007/UP037/SIM118, #274 B904). This batch addresses **safe, behavior-preserving** simplifications that surface only under explicit `--select` (the repo's default lint config is E/F/I only):

- **C401 / C403** — generator-in-`set()` and list-comprehension-in-`set()` rewritten as set comprehensions (3 sites)
- **C416** — redundant `{k: v for k, v in pairs}` rewritten as `dict(pairs)` (3 sites, incl. SQLAlchemy `.all()` row pairs)
- **C420** — `{k: None for k in iter}` rewritten as `dict.fromkeys(iter)` (1 site)
- **PIE790** — drop unnecessary `pass` after docstring (14 sites)

## Why these are safe

Every change is semantically identical to its replacement (verified per-site before applying):

- `set(gen)` / `set([lc])` → `{ ... }`: identical element set
- `{ k: v for k, v in two_tuples }` → `dict(two_tuples)`: identical mapping (rows are `(status, count)` / `(alert_type, count)` pairs)
- `{ k: None for k in it }` → `dict.fromkeys(it)`: defaults value to `None`, identical
- `pass` after a docstring: the docstring already satisfies the non-empty-body requirement

PIE807 (`lambda: {}` → `dict`) was **deliberately excluded**: those sites pass the lambda as a kwarg to `MagicMock(...)`, where call-vs-config semantics make the autofix non-obvious — left for separate review.

## Validation

- `ruff check .` clean (default E/F/I config); `--select C401,C403,C416,C420,PIE790` reports 0 remaining
- `pytest -q`: **2891 passed, 19 skipped** — unchanged baseline, no regressions

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
