### PR TITLE
fix(hook): repair duplicate-query detection in PreToolUse hook

### DIFF
--- a/scripts/hooks/check_duplicate_queries.py
+++ b/scripts/hooks/check_duplicate_queries.py
@@ -8,6 +8,7 @@ import argparse
 import json
 import re
 import sys
+from typing import TypedDict
 
 # Pre-computed patterns loaded from existing code
 PATTERNS = {
@@ -50,7 +51,7 @@ def extract_query_shapes(content: str) -> list[str]:
         model = match.group(1)
         start = match.end()
         remaining = content[start:]
-        where_match = re.search(r"\.where\(([^)]+)\)", remaining[start:])
+        where_match = re.search(r"\.where\(([^)]+)\)", remaining)
         if where_match:
             where_clause = where_match.group(1)
             conditions = re.findall(r"(\w+)\.(\w+)\s*==", where_clause)
@@ -60,7 +61,14 @@ def extract_query_shapes(content: str) -> list[str]:
     return shapes
 
 
-def check_duplicates(content: str) -> list[dict]:
+class DuplicateCheck(TypedDict):
+    """Result of checking content against the known pattern registry."""
+
+    duplicates: list[dict[str, str]]
+    shapes_found: list[str]
+
+
+def check_duplicates(content: str) -> DuplicateCheck:
     """Check content against known patterns."""
     duplicates = []
     shapes = extract_query_shapes(content)
@@ -98,7 +106,8 @@ def main():
         sys.exit(0)
 
     # Check for duplicates
-    duplicates = check_duplicates(content)
+    result = check_duplicates(content)
+    duplicates = result["duplicates"]
     if duplicates:
         dup = duplicates[0]
         print(

--- a/tests/api/test_cross_session_routes.py
+++ b/tests/api/test_cross_session_routes.py
@@ -1,0 +1,374 @@
+"""Tests for cross-session failure clustering API routes.
+
+Exercises the route handlers in ``api/cross_session_routes.py`` directly via
+their endpoint functions (the ``api_repo_factory`` + ``_get_route_endpoint``
+convention established in ``tests/test_api_contract.py``).
+
+Note: ``tests/test_cross_session_clustering.py`` covers the
+``CrossSessionClusterAnalyzer`` logic itself; these tests cover the HTTP route
+handlers that wrap it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.routing import APIRoute
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+import api.main as api_main
+from agent_debugger_sdk.core.context import configure_event_pipeline
+from agent_debugger_sdk.core.events import EventType, Session, SessionStatus, TraceEvent
+from api import app_context
+from api import services as api_services
+from collector.buffer import get_event_buffer
+from collector.server import configure_storage
+from storage import Base, TraceRepository
+
+
+def _get_route_endpoint(path: str, method: str):
+    """Return the route endpoint function for a path/method pair."""
+    for route in api_main.app.routes:
+        if isinstance(route, APIRoute) and route.path == path and method.upper() in route.methods:
+            return route.endpoint
+    raise AssertionError(f"Route {method} {path} not found")
+
+
+@pytest.fixture
+def api_repo_factory(tmp_path, monkeypatch):
+    """Build an isolated sqlite DB and wire app_context + collector storage to it."""
+    db_path = tmp_path / "cross-session-routes.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", echo=False)
+    session_maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    monkeypatch.setattr(app_context, "engine", engine)
+    monkeypatch.setattr(app_context, "async_session_maker", session_maker)
+
+    buffer = get_event_buffer()
+    buffer._events.clear()
+    buffer._queues.clear()
+    buffer._session_activity.clear()
+
+    async def setup() -> None:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio.run(setup())
+
+    configure_storage(session_maker)
+    configure_event_pipeline(
+        buffer,
+        persist_event=api_services.persist_event,
+        persist_checkpoint=api_services.persist_checkpoint,
+        persist_session_start=api_services.persist_session_start,
+        persist_session_update=api_services.persist_session_update,
+    )
+
+    yield session_maker
+
+    configure_storage(None)
+    configure_event_pipeline(None)
+    asyncio.run(engine.dispose())
+
+
+def _make_session(
+    session_id: str,
+    *,
+    agent_name: str = "test_agent",
+    framework: str = "pytest",
+    status: SessionStatus = SessionStatus.COMPLETED,
+) -> Session:
+    return Session(
+        id=session_id,
+        agent_name=agent_name,
+        framework=framework,
+        started_at=datetime(2026, 7, 1, 10, 0, tzinfo=timezone.utc),
+        ended_at=datetime(2026, 7, 1, 11, 0, tzinfo=timezone.utc),
+        status=status,
+        total_cost_usd=0.25,
+        total_tokens=500,
+        llm_calls=2,
+        tool_calls=4,
+        errors=1,
+        replay_value=0.6,
+        config={"mode": "test"},
+        tags=["cluster-test"],
+    )
+
+
+def _make_event(
+    session_id: str,
+    event_type: EventType,
+    name: str = "test_event",
+    *,
+    importance: float = 0.5,
+) -> TraceEvent:
+    return TraceEvent(
+        session_id=session_id,
+        parent_id=None,
+        event_type=event_type,
+        name=name,
+        data={},
+        metadata={},
+        importance=importance,
+        upstream_event_ids=[],
+    )
+
+
+def _fingerprint(event_type: EventType, name: str) -> str:
+    """Mirror the route's fingerprint computation (TraceEvent has no fingerprint attr)."""
+    return f"{event_type}:{name}"
+
+
+# -----------------------------------------------------------------------------
+# GET /api/clusters  ->  get_cross_session_clusters
+# -----------------------------------------------------------------------------
+
+
+def test_get_clusters_returns_recurring_failure_cluster(api_repo_factory):
+    """Multiple sessions sharing the same failure fingerprint form one cluster."""
+    fp = _fingerprint(EventType.ERROR, "timeout")
+
+    async def seed() -> None:
+        async with api_repo_factory() as session:
+            repo = TraceRepository(session)
+            for sid in ("cs-cluster-1", "cs-cluster-2", "cs-cluster-3"):
+                await repo.create_session(_make_session(sid))
+                await repo.add_event(_make_event(sid, EventType.ERROR, name="timeout"))
+            await session.commit()
+
+    asyncio.run(seed())
+
+    clusters_endpoint = _get_route_endpoint("/api/clusters", "GET")
+
+    async def run():
+        async with api_repo_factory() as session:
+            repo = TraceRepository(session)
+            return await clusters_endpoint(limit=50, min_count=2, repo=repo)
+
+    payload = asyncio.run(run())
+
+    assert payload["min_count"] == 2
+    assert payload["total"] == 1
+    clusters = payload["clusters"]
+    assert len(clusters) == 1
+    assert clusters[0]["fingerprint"] == fp
+    assert clusters[0]["count"] == 3
+
+
+def test_get_clusters_empty_when_no_sessions(api_repo_factory):
+    """No sessions at all -> empty clusters response."""
+
+    clusters_endpoint = _get_route_endpoint("/api/clusters", "GET")
+
+    async def run():
+        async with api_repo_factory() as session:
+            repo = TraceRepository(session)
+            return await clusters_endpoint(limit=50, min_count=2, repo=repo)
+
+    payload = asyncio.run(run())
+
+    assert payload["clusters"] == []
+    assert payload["total"] == 0
+    assert payload["min_count"] == 2
+
+
+def test_get_clusters_no_failures_when_only_tool_calls(api_repo_factory):
+    """Non-failure events (severity <= 0.7) produce no failure fingerprints."""
+    from collector.intelligence.compute import compute_event_ranking  # noqa: F401  # sanity import
+
+    async def seed() -> None:
+        async with api_repo_factory() as session:
+            repo = TraceRepository(session)
+            await repo.create_session(_make_session("cs-tools-1"))
+            await repo.add_event(_make_event("cs-tools-1", EventType.TOOL_CALL, name="search"))
+            await repo.create_session(_make_session("cs-tools-2"))
+            await repo.add_event(_make_event("cs-tools-2", EventType.TOOL_CALL, name="search"))
+            await session.commit()
+
+    asyncio.run(seed())
+
+    clusters_endpoint = _get_route_endpoint("/api/clusters", "GET")
+
+    async def run():
+        async with api_repo_factory() as session:
+            repo = TraceRepository(session)
+            return await clusters_endpoint(limit=50, min_count=1, repo=repo)
+
+    payload = asyncio.run(run())
+
+    assert payload["total"] == 0
+    assert payload["clusters"] == []
+
+
+def test_get_clusters_min_count_filters_below_threshold(api_repo_factory):
+    """A cluster with count below min_count is filtered out."""
+    async def seed() -> None:
+        async with api_repo_factory() as session:
+            repo = TraceRepository(session)
+            # Two sessions share the failure -> cluster count would be 2.
+            await repo.create_session(_make_session("cs-min-1"))
+            await repo.add_event(_make_event("cs-min-1", EventType.ERROR, name="conn_reset"))
+            await repo.create_session(_make_session("cs-min-2"))
+            await repo.add_event(_make_event("cs-min-2", EventType.ERROR, name="conn_reset"))
+            await session.commit()
+
+    asyncio.run(seed())
+
+    clusters_endpoint = _get_route_endpoint("/api/clusters", "GET")
+
+    async def run():
+        async with api_repo_factory() as session:
+            repo = TraceRepository(session)
+            # Demand at least 3 sessions; only 2 are present -> filtered out.
+            return await clusters_endpoint(limit=50, min_count=3, repo=repo)
+
+    payload = asyncio.run(run())
+
+    assert payload["min_count"] == 3
+    assert payload["total"] == 0
+    assert payload["clusters"] == []
+
+
+def test_get_clusters_limit_caps_results(api_repo_factory):
+    """limit slices the resulting cluster list after min_count filtering."""
+    async def seed() -> None:
+        async with api_repo_factory() as session:
+            repo = TraceRepository(session)
+            # Each session carries two distinct failure fingerprints shared across
+            # both sessions -> two clusters, each with count 2.
+            for sid in ("cs-limit-1", "cs-limit-2"):
+                await repo.create_session(_make_session(sid))
+                await repo.add_event(_make_event(sid, EventType.ERROR, name="timeout"))
+                await repo.add_event(_make_event(sid, EventType.ERROR, name="conn_reset"))
+            await session.commit()
+
+    asyncio.run(seed())
+
+    clusters_endpoint = _get_route_endpoint("/api/clusters", "GET")
+
+    async def run():
+        async with api_repo_factory() as session:
+            repo = TraceRepository(session)
+            return await clusters_endpoint(limit=1, min_count=2, repo=repo)
+
+    payload = asyncio.run(run())
+
+    assert payload["total"] == 1
+    assert len(payload["clusters"]) == 1
+
+
+def test_get_clusters_skips_sessions_without_events(api_repo_factory):
+    """A session with no events is skipped; remaining failure still clusters."""
+    async def seed() -> None:
+        async with api_repo_factory() as session:
+            repo = TraceRepository(session)
+            await repo.create_session(_make_session("cs-with-events"))
+            await repo.add_event(_make_event("cs-with-events", EventType.ERROR, name="timeout"))
+            # Empty session -> skipped inside the handler.
+            await repo.create_session(_make_session("cs-empty"))
+            await session.commit()
+
+    asyncio.run(seed())
+
+    clusters_endpoint = _get_route_endpoint("/api/clusters", "GET")
+
+    async def run():
+        async with api_repo_factory() as session:
+            repo = TraceRepository(session)
+            return await clusters_endpoint(limit=50, min_count=1, repo=repo)
+
+    payload = asyncio.run(run())
+
+    assert payload["total"] == 1
+    assert payload["clusters"][0]["count"] == 1
+    assert payload["clusters"][0]["sessions"] == ["cs-with-events"]
+
+
+# -----------------------------------------------------------------------------
+# GET /api/clusters/{fingerprint}/sessions  ->  get_cluster_sessions
+# -----------------------------------------------------------------------------
+
+
+def test_get_cluster_sessions_returns_matching_sessions(api_repo_factory):
+    """Sessions containing the queried fingerprint are returned."""
+    fp = _fingerprint(EventType.ERROR, "timeout")
+
+    async def seed() -> None:
+        async with api_repo_factory() as session:
+            repo = TraceRepository(session)
+            await repo.create_session(_make_session("cs-sess-1"))
+            await repo.add_event(_make_event("cs-sess-1", EventType.ERROR, name="timeout"))
+            await repo.create_session(_make_session("cs-sess-2"))
+            await repo.add_event(_make_event("cs-sess-2", EventType.ERROR, name="timeout"))
+            # Unrelated session that should not appear.
+            await repo.create_session(_make_session("cs-sess-other"))
+            await repo.add_event(_make_event("cs-sess-other", EventType.TOOL_CALL, name="search"))
+            await session.commit()
+
+    asyncio.run(seed())
+
+    sessions_endpoint = _get_route_endpoint("/api/clusters/{fingerprint}/sessions", "GET")
+
+    async def run():
+        async with api_repo_factory() as session:
+            repo = TraceRepository(session)
+            return await sessions_endpoint(fingerprint=fp, repo=repo)
+
+    payload = asyncio.run(run())
+
+    assert payload["fingerprint"] == fp
+    assert payload["total"] == 2
+    returned_ids = {s.id for s in payload["sessions"]}
+    assert returned_ids == {"cs-sess-1", "cs-sess-2"}
+    # SessionSchema shape sanity check.
+    first = payload["sessions"][0]
+    assert first.agent_name == "test_agent"
+    assert first.framework == "pytest"
+    assert first.errors == 1
+
+
+def test_get_cluster_sessions_404_when_no_match(api_repo_factory):
+    """An absent fingerprint raises HTTPException 404."""
+    from fastapi import HTTPException
+
+    async def seed() -> None:
+        async with api_repo_factory() as session:
+            repo = TraceRepository(session)
+            await repo.create_session(_make_session("cs-unrelated"))
+            await repo.add_event(_make_event("cs-unrelated", EventType.TOOL_CALL, name="search"))
+            await session.commit()
+
+    asyncio.run(seed())
+
+    sessions_endpoint = _get_route_endpoint("/api/clusters/{fingerprint}/sessions", "GET")
+
+    async def run():
+        async with api_repo_factory() as session:
+            repo = TraceRepository(session)
+            return await sessions_endpoint(fingerprint="error:nonexistent", repo=repo)
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(run())
+
+    assert exc_info.value.status_code == 404
+    assert "error:nonexistent" in exc_info.value.detail
+
+
+def test_get_cluster_sessions_404_on_empty_db(api_repo_factory):
+    """No sessions at all -> HTTPException 404."""
+    from fastapi import HTTPException
+
+    sessions_endpoint = _get_route_endpoint("/api/clusters/{fingerprint}/sessions", "GET")
+
+    async def run():
+        async with api_repo_factory() as session:
+            repo = TraceRepository(session)
+            return await sessions_endpoint(fingerprint="error:timeout", repo=repo)
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(run())
+
+    assert exc_info.value.status_code == 404

--- a/tests/sdk/checkpoints/__init__.py
+++ b/tests/sdk/checkpoints/__init__.py
@@ -1,0 +1,1 @@
+"""Checkpoints SDK tests."""

--- a/tests/sdk/checkpoints/test_hooks.py
+++ b/tests/sdk/checkpoints/test_hooks.py
@@ -1,0 +1,490 @@
+"""Tests for restore hooks and automatic replay orchestration.
+
+Covers ``agent_debugger_sdk/checkpoints/hooks.py``:
+
+- The ``RestoreHook`` runtime-checkable protocol.
+- ``_langchain_hook`` and ``_generic_hook`` for both matching and non-matching
+  state types (covering the ``isinstance`` False branches).
+- ``apply_restore_hook`` dispatch, fallback, and exception handling.
+- ``AutoReplayManager`` construction and replay semantics, including early
+  termination when the per-event callback returns ``False``.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from agent_debugger_sdk.checkpoints.hooks import (
+    RESTORE_HOOK_REGISTRY,
+    AutoReplayManager,
+    RestoreHook,
+    _generic_hook,
+    _langchain_hook,
+    apply_restore_hook,
+)
+from agent_debugger_sdk.checkpoints.schemas import (
+    BaseCheckpointState,
+    CustomCheckpointState,
+    LangChainCheckpointState,
+)
+
+
+class TestRestoreHookProtocol:
+    """Tests for the runtime-checkable RestoreHook protocol."""
+
+    def test_async_callable_satisfies_protocol(self) -> None:
+        """An object with an async ``__call__`` should be recognized as a RestoreHook."""
+
+        async def my_hook(state: BaseCheckpointState, target: Any) -> Any:  # noqa: ARG001
+            return target
+
+        # runtime_checkable protocols only check attribute presence, but an async
+        # function exposes __call__, so it satisfies the protocol structurally.
+        assert isinstance(my_hook, RestoreHook)
+
+    def test_plain_object_does_not_satisfy_protocol(self) -> None:
+        """An object without ``__call__`` should not satisfy the RestoreHook protocol."""
+
+        class NotAHook:
+            pass
+
+        assert not isinstance(NotAHook(), RestoreHook)
+
+    def test_builtin_functions_satisfy_protocol_via_call(self) -> None:
+        """Builtins expose ``__call__`` so they pass the runtime structural check.
+
+        This documents that runtime_checkable only inspects for ``__call__``;
+        the registry still expects an awaitable result.
+        """
+
+        async def fake(state: BaseCheckpointState, target: Any) -> Any:  # noqa: ARG001
+            return target
+
+        assert isinstance(fake, RestoreHook)
+
+
+class TestLangChainHook:
+    """Tests for the default ``_langchain_hook``."""
+
+    @pytest.mark.asyncio
+    async def test_restores_messages_and_intermediate_steps(self) -> None:
+        """LangChain state should populate messages + intermediate_steps on target."""
+        state = LangChainCheckpointState(
+            messages=[{"role": "user", "content": "hi"}],
+            intermediate_steps=[{"tool": "search", "result": "ok"}],
+            run_name="run-1",
+            run_id="abc",
+        )
+        target = SimpleNamespace()
+
+        result = await _langchain_hook(state, target)
+
+        assert result is target
+        assert result.messages == [{"role": "user", "content": "hi"}]
+        assert result.intermediate_steps == [{"tool": "search", "result": "ok"}]
+
+    @pytest.mark.asyncio
+    async def test_returns_target_unchanged_for_custom_state(self) -> None:
+        """A non-LangChain state should pass through without mutation (47->50 branch)."""
+        state = CustomCheckpointState(data={"k": "v"})
+        target = SimpleNamespace()
+
+        result = await _langchain_hook(state, target)
+
+        assert result is target
+        # The langchain hook must not add langchain-specific attributes for
+        # mismatched state types.
+        assert not hasattr(result, "messages")
+        assert not hasattr(result, "intermediate_steps")
+
+    @pytest.mark.asyncio
+    async def test_returns_target_unchanged_for_base_state(self) -> None:
+        """A bare BaseCheckpointState should also pass through unchanged."""
+        state = BaseCheckpointState(framework="langchain", label="base")
+        target = SimpleNamespace(existing=True)
+
+        result = await _langchain_hook(state, target)
+
+        assert result is target
+        assert result.existing is True
+        assert not hasattr(result, "messages")
+
+
+class TestGenericHook:
+    """Tests for the ``_generic_hook`` fallback."""
+
+    @pytest.mark.asyncio
+    async def test_copies_data_for_custom_state(self) -> None:
+        """CustomCheckpointState.data should be copied onto the target."""
+        state = CustomCheckpointState(data={"answer": 42})
+        target = SimpleNamespace()
+
+        result = await _generic_hook(state, target)
+
+        assert result is target
+        assert result.data == {"answer": 42}
+
+    @pytest.mark.asyncio
+    async def test_returns_target_unchanged_for_langchain_state(self) -> None:
+        """A LangChain state should not be mutated by the generic hook (58->60 branch)."""
+        state = LangChainCheckpointState(messages=[{"r": 1}])
+        target = SimpleNamespace()
+
+        result = await _generic_hook(state, target)
+
+        assert result is target
+        assert not hasattr(result, "data")
+
+    @pytest.mark.asyncio
+    async def test_returns_target_unchanged_for_base_state(self) -> None:
+        """A bare BaseCheckpointState should pass through without a data attribute."""
+        state = BaseCheckpointState(framework="custom")
+        target = SimpleNamespace(marker="x")
+
+        result = await _generic_hook(state, target)
+
+        assert result is target
+        assert result.marker == "x"
+        assert not hasattr(result, "data")
+
+
+class TestApplyRestoreHookDispatch:
+    """Tests for ``apply_restore_hook`` registry lookup and dispatch."""
+
+    @pytest.mark.asyncio
+    async def test_dispatches_to_langchain_hook(self) -> None:
+        """The ``langchain`` framework should resolve to the registered langchain hook."""
+        state = LangChainCheckpointState(messages=[{"m": 1}], intermediate_steps=[{"s": 2}])
+        target = SimpleNamespace()
+
+        result = await apply_restore_hook("langchain", state, target)
+
+        assert result is target
+        assert result.messages == [{"m": 1}]
+        assert result.intermediate_steps == [{"s": 2}]
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_generic_hook_for_unknown_framework(self) -> None:
+        """Unknown frameworks should fall back to the generic hook."""
+        state = CustomCheckpointState(data={"payload": "yes"})
+        target = SimpleNamespace()
+
+        result = await apply_restore_hook("some-unknown-framework", state, target)
+
+        assert result is target
+        assert result.data == {"payload": "yes"}
+
+    @pytest.mark.asyncio
+    async def test_generic_fallback_handles_non_custom_state(self) -> None:
+        """The generic fallback should not mutate non-Custom state (58->60 via dispatch)."""
+        state = LangChainCheckpointState(messages=[{"a": 1}])
+        target = SimpleNamespace()
+
+        result = await apply_restore_hook("not-a-framework", state, target)
+
+        assert result is target
+        # generic hook only sets ``data`` for CustomCheckpointState
+        assert not hasattr(result, "data")
+
+    @pytest.mark.asyncio
+    async def test_langchain_hook_handles_non_langchain_state_via_dispatch(self) -> None:
+        """Dispatching langchain with a non-langchain state covers the 47->50 branch."""
+        state = CustomCheckpointState(data={"x": 1})
+        target = SimpleNamespace()
+
+        result = await apply_restore_hook("langchain", state, target)
+
+        assert result is target
+        # langchain hook ignores CustomCheckpointState
+        assert not hasattr(result, "messages")
+        assert not hasattr(result, "intermediate_steps")
+
+
+class TestApplyRestoreHookErrorHandling:
+    """Tests for ``apply_restore_hook`` exception isolation."""
+
+    @pytest.mark.asyncio
+    async def test_returns_target_unchanged_when_hook_raises(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A failing hook should log and return the target unchanged (lines 90-92)."""
+
+        async def boom(state: BaseCheckpointState, target: Any) -> Any:  # noqa: ARG001
+            raise RuntimeError("hook exploded")
+
+        RESTORE_HOOK_REGISTRY["failing"] = boom
+        try:
+            target = SimpleNamespace()
+            state = BaseCheckpointState(framework="failing")
+
+            with caplog.at_level(
+                logging.ERROR, logger="agent_debugger_sdk.checkpoints.hooks"
+            ):
+                result = await apply_restore_hook("failing", state, target)
+
+            assert result is target
+            assert any("failing" in record.message for record in caplog.records)
+            assert any(
+                record.levelno == logging.ERROR
+                and record.name == "agent_debugger_sdk.checkpoints.hooks"
+                for record in caplog.records
+            )
+            # logger.exception records the traceback text
+            assert any("hook exploded" in record.exc_text or "RuntimeError" in (
+                record.exc_text or ""
+            ) for record in caplog.records)
+        finally:
+            RESTORE_HOOK_REGISTRY.pop("failing", None)
+
+    @pytest.mark.asyncio
+    async def test_hook_raising_value_error_also_isolated(self) -> None:
+        """Any Exception subclass (not just RuntimeError) should be isolated."""
+
+        async def bad(state: BaseCheckpointState, target: Any) -> Any:  # noqa: ARG001
+            raise ValueError("bad value")
+
+        RESTORE_HOOK_REGISTRY["bad"] = bad
+        try:
+            target = SimpleNamespace(original=True)
+            state = BaseCheckpointState(framework="bad")
+
+            result = await apply_restore_hook("bad", state, target)
+
+            assert result is target
+            assert result.original is True
+        finally:
+            RESTORE_HOOK_REGISTRY.pop("bad", None)
+
+
+class TestRestoreHookRegistryCustomization:
+    """Tests for custom hook registration in RESTORE_HOOK_REGISTRY."""
+
+    @pytest.mark.asyncio
+    async def test_custom_registered_hook_is_invoked(self) -> None:
+        """A user-registered hook should be used in place of the fallback."""
+
+        async def my_hook(state: BaseCheckpointState, target: Any) -> Any:
+            target.framework_seen = state.framework
+            target.touched = True
+            return target
+
+        RESTORE_HOOK_REGISTRY["my-framework"] = my_hook
+        try:
+            target = SimpleNamespace()
+            state = BaseCheckpointState(framework="my-framework", label="lbl")
+
+            result = await apply_restore_hook("my-framework", state, target)
+
+            assert result is target
+            assert result.framework_seen == "my-framework"
+            assert result.touched is True
+        finally:
+            RESTORE_HOOK_REGISTRY.pop("my-framework", None)
+
+    def test_langchain_registered_by_default(self) -> None:
+        """The default registry should expose the langchain hook."""
+        assert "langchain" in RESTORE_HOOK_REGISTRY
+        assert RESTORE_HOOK_REGISTRY["langchain"] is _langchain_hook
+
+    def test_registry_does_not_include_generic_by_default(self) -> None:
+        """The generic hook is the implicit fallback, not a registry entry."""
+        # The generic hook is only reached when a framework is absent.
+        assert "custom" not in RESTORE_HOOK_REGISTRY
+
+
+class TestAutoReplayManagerInit:
+    """Tests for ``AutoReplayManager.__init__`` (lines 113-116)."""
+
+    def test_defaults_for_framework_and_callback(self) -> None:
+        """Omitted framework/on_event should default to ``custom`` and ``None``."""
+        events: list[dict[str, Any]] = [{"id": 1}]
+
+        manager = AutoReplayManager(events)
+
+        assert manager.events is events
+        assert manager.framework == "custom"
+        assert manager.on_event is None
+        assert manager.replayed == []
+
+    def test_stores_custom_arguments(self) -> None:
+        """Custom framework and on_event should be stored verbatim."""
+        events = [{"id": "a"}, {"id": "b"}]
+
+        def on_event(event: dict[str, Any]) -> bool:
+            return True
+
+        manager = AutoReplayManager(events, framework="langchain", on_event=on_event)
+
+        assert manager.events == [{"id": "a"}, {"id": "b"}]
+        assert manager.framework == "langchain"
+        assert manager.on_event is on_event
+        assert manager.replayed == []
+
+    def test_replayed_starts_empty_independent_per_instance(self) -> None:
+        """Each instance gets its own ``replayed`` list (no shared mutable default)."""
+        m1 = AutoReplayManager([])
+        m2 = AutoReplayManager([])
+
+        m1.replayed.append({"x": 1})
+        assert m2.replayed == []
+
+
+class TestAutoReplayManagerRun:
+    """Tests for ``AutoReplayManager.run`` (lines 124-130)."""
+
+    @pytest.mark.asyncio
+    async def test_empty_events_returns_empty_list(self) -> None:
+        """With no events, run() should return an empty list without invoking callback."""
+        called: list[dict[str, Any]] = []
+
+        def on_event(event: dict[str, Any]) -> bool:
+            called.append(event)
+            return True
+
+        manager = AutoReplayManager([], framework="custom", on_event=on_event)
+
+        result = await manager.run()
+
+        assert result == []
+        assert manager.replayed == []
+        assert called == []
+
+    @pytest.mark.asyncio
+    async def test_no_callback_replays_all_events(self) -> None:
+        """Without an on_event callback, every event should be replayed."""
+        events = [{"seq": 1}, {"seq": 2}, {"seq": 3}]
+        manager = AutoReplayManager(events)
+
+        result = await manager.run()
+
+        assert result == events
+        assert manager.replayed == events
+
+    @pytest.mark.asyncio
+    async def test_callback_returning_true_replays_all(self) -> None:
+        """A truthy callback return value should let replay continue to the end."""
+        events = [{"seq": 1}, {"seq": 2}]
+        seen: list[dict[str, Any]] = []
+
+        def on_event(event: dict[str, Any]) -> bool:
+            seen.append(event)
+            return True
+
+        manager = AutoReplayManager(events, on_event=on_event)
+
+        result = await manager.run()
+
+        assert result == events
+        assert seen == events
+
+    @pytest.mark.asyncio
+    async def test_callback_returning_false_stops_early(self) -> None:
+        """Returning exactly ``False`` should break the replay loop immediately."""
+        events = [{"seq": 1}, {"seq": 2}, {"seq": 3}]
+        seen: list[dict[str, Any]] = []
+
+        def on_event(event: dict[str, Any]) -> bool:
+            seen.append(event)
+            # Stop right before the second event is replayed.
+            return event["seq"] != 1
+
+        manager = AutoReplayManager(events, on_event=on_event)
+
+        result = await manager.run()
+
+        # The callback saw the first event (returning False), so the loop broke
+        # before appending anything. The returned list reflects what was
+        # actually replayed.
+        assert seen == [{"seq": 1}]
+        assert result == []
+        assert manager.replayed == []
+
+    @pytest.mark.asyncio
+    async def test_callback_returning_none_continues_replay(self) -> None:
+        """A ``None`` return is falsy but is not ``False``, so replay must continue.
+
+        This locks in the ``result is False`` identity check (line 127).
+        """
+        events = [{"seq": 1}, {"seq": 2}]
+
+        def on_event(event: dict[str, Any]) -> None:
+            return None
+
+        manager = AutoReplayManager(events, on_event=on_event)
+
+        result = await manager.run()
+
+        assert result == events
+        assert manager.replayed == events
+
+    @pytest.mark.asyncio
+    async def test_callback_returning_zero_continues_replay(self) -> None:
+        """``0`` is falsy but not identical to ``False``; replay should continue."""
+        events = [{"seq": 1}, {"seq": 2}, {"seq": 3}]
+
+        def on_event(event: dict[str, Any]) -> int:
+            return 0
+
+        manager = AutoReplayManager(events, on_event=on_event)
+
+        result = await manager.run()
+
+        assert result == events
+        assert manager.replayed == events
+
+    @pytest.mark.asyncio
+    async def test_callback_receives_each_event_in_order(self) -> None:
+        """The per-event callback should observe events in their list order."""
+        events = [{"seq": i} for i in range(5)]
+        seen: list[int] = []
+
+        def on_event(event: dict[str, Any]) -> bool:
+            seen.append(event["seq"])
+            return True
+
+        manager = AutoReplayManager(events, on_event=on_event)
+
+        await manager.run()
+
+        assert seen == [0, 1, 2, 3, 4]
+
+    @pytest.mark.asyncio
+    async def test_run_does_not_reset_replayed_between_calls(self) -> None:
+        """Calling run() twice appends to the same accumulating ``replayed`` list.
+
+        The manager does not reset ``replayed`` between runs, and run() returns
+        the live ``self.replayed`` list (not a copy), so prior results observe
+        later mutations. Document this current-implementation behavior.
+        """
+        events = [{"seq": 1}]
+        manager = AutoReplayManager(events)
+
+        first = await manager.run()
+        # first is the live self.replayed list reference.
+        assert first is manager.replayed
+        assert first == [{"seq": 1}]
+
+        second = await manager.run()
+        # second is the same list object, now holding two appends.
+        assert second is first
+        assert second == [{"seq": 1}, {"seq": 1}]
+        assert manager.replayed == [{"seq": 1}, {"seq": 1}]
+
+    @pytest.mark.asyncio
+    async def test_false_on_first_event_yields_empty_replay(self) -> None:
+        """Returning False on the very first event yields an empty replayed list."""
+        events = [{"seq": 1}, {"seq": 2}]
+
+        def on_event(event: dict[str, Any]) -> bool:
+            return False
+
+        manager = AutoReplayManager(events, on_event=on_event)
+
+        result = await manager.run()
+
+        assert result == []
+        assert manager.replayed == []

--- a/tests/test_check_duplicate_queries.py
+++ b/tests/test_check_duplicate_queries.py
@@ -1,0 +1,118 @@
+"""Tests for the PreToolUse duplicate-query hook shape extractor.
+
+Regression coverage for a double-offset bug where ``remaining[start:]`` skipped the
+``.where(...)`` clause for any select() that was not at the very start of the content,
+so non-leading duplicate queries went undetected.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_HOOK_PATH = Path(__file__).resolve().parents[1] / "scripts" / "hooks" / "check_duplicate_queries.py"
+
+
+@pytest.fixture(scope="module")
+def hook():
+    """Load the hook module directly from its file path."""
+    spec = importlib.util.spec_from_file_location("check_duplicate_queries", _HOOK_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_extract_shape_leading_select(hook):
+    """A select() at the start of the content is matched."""
+    content = "q = select(EventModel).where(EventModel.session_id == sid)\n"
+    assert hook.extract_query_shapes(content) == ["EventModel.where[session_id]"]
+
+
+def test_extract_shape_non_leading_select(hook):
+    """Regression: a select() preceded by other code must still have its where() found.
+
+    Previously ``remaining[start:]`` double-offset the search window, so the where
+    clause immediately following a non-leading select() fell in the skipped region.
+    """
+    content = (
+        "# leading comment padding\n"
+        "# more padding to push select forward\n"
+        "async def list_events(session, sid):\n"
+        "    return await session.execute(select(EventModel).where(EventModel.session_id == sid))\n"
+    )
+    assert hook.extract_query_shapes(content) == ["EventModel.where[session_id]"]
+
+
+def test_extract_shape_unknown_model_allowed(hook):
+    """A select on a model not in the pattern registry is still extracted but not flagged."""
+    content = "q = select(NewModel).where(NewModel.foo == bar)\n"
+    assert hook.extract_query_shapes(content) == ["NewModel.where[foo]"]
+
+
+def test_extract_shape_multiple_conditions_sorted(hook):
+    """Where condition field names are sorted alphabetically and are order-independent."""
+    content = (
+        "q = select(SessionModel).where(SessionModel.tenant_id == t, SessionModel.id == i)\n"
+    )
+    assert hook.extract_query_shapes(content) == ["SessionModel.where[id, tenant_id]"]
+
+
+def test_check_duplicates_flags_known_pattern(hook):
+    """A known duplicate shape is reported as a duplicate."""
+    content = "q = select(EventModel).where(EventModel.session_id == sid)\n"
+    result = hook.check_duplicates(content)
+    assert result["duplicates"]
+    assert result["duplicates"][0]["shape"] == "EventModel.where[session_id]"
+    assert result["duplicates"][0]["method"] == "list_events"
+
+
+def test_check_duplicates_allows_unknown_pattern(hook):
+    """A shape not in the registry produces no duplicates."""
+    content = "q = select(BrandNewModel).where(BrandNewModel.x == y)\n"
+    result = hook.check_duplicates(content)
+    assert result["duplicates"] == []
+
+
+def test_main_denies_in_scope_duplicate(hook, capsys, monkeypatch):
+    """main() denies an in-scope path with a duplicate query."""
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "check_duplicate_queries.py",
+            "--path",
+            "api/foo.py",
+            "--content",
+            "q = select(EventModel).where(EventModel.session_id == sid)\n",
+        ],
+    )
+    with pytest.raises(SystemExit) as exc:
+        hook.main()
+    import json
+
+    out = json.loads(capsys.readouterr().out)
+    assert exc.value.code == 1
+    assert out["decision"] == "deny"
+
+
+def test_main_allows_out_of_scope_path(hook, capsys, monkeypatch):
+    """main() allows paths outside api/ auth/ collector/."""
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "check_duplicate_queries.py",
+            "--path",
+            "frontend/src/App.tsx",
+            "--content",
+            "select(EventModel).where(EventModel.session_id == sid)\n",
+        ],
+    )
+    with pytest.raises(SystemExit) as exc:
+        hook.main()
+    import json
+
+    out = json.loads(capsys.readouterr().out)
+    assert exc.value.code == 0
+    assert out["decision"] == "allow"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,21 @@
-"""Tests for the peaky-peek CLI."""
+"""Tests for the peaky-peek CLI.
+
+Covers two related but distinct CLI modules:
+
+* ``api.cli``  -- server CLI (``peaky-peek-server`` entry point).
+* ``agent_debugger_sdk.cli`` -- SDK CLI (``peaky-peek`` entry point) with the
+  ``seed``/``serve``/``demo`` subcommands. This is the primary coverage target.
+"""
+
+import subprocess
+import sys
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Existing tests for the api.cli module (server CLI) -- preserved.
+# ---------------------------------------------------------------------------
 
 
 def test_cli_module_importable():
@@ -10,9 +27,6 @@ def test_cli_module_importable():
 
 def test_cli_version_flag(capsys):
     """--version should print version string."""
-    import sys
-    from unittest.mock import patch
-
     with patch.object(sys, "argv", ["peaky-peek", "--version"]):
         try:
             from api.cli import main
@@ -24,3 +38,332 @@ def test_cli_version_flag(capsys):
 
     captured = capsys.readouterr()
     assert "peaky-peek" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Tests for agent_debugger_sdk.cli (SDK CLI: seed / serve / demo).
+# ---------------------------------------------------------------------------
+
+from agent_debugger_sdk import cli as sdk_cli  # noqa: E402
+
+
+def _make_fake_path(exists_return: bool):
+    """Build a Path stand-in controlling ``exists()`` for ``run_seed``.
+
+    Replicates the small slice of pathlib.Path that ``run_seed`` exercises:
+    ``Path(__file__).parent.parent / "scripts" / "seed_demo_sessions.py"``.
+    """
+
+    class _FakePath:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        @property
+        def parent(self):
+            return self
+
+        def __truediv__(self, _other):
+            return self
+
+        def __str__(self):
+            return "/fake/scripts/seed_demo_sessions.py"
+
+        def exists(self):
+            return exists_return
+
+    return _FakePath
+
+
+class _FakePopen:
+    """Minimal subprocess.Popen double recording terminate()/wait() calls."""
+
+    instances: list["_FakePopen"] = []
+
+    def __init__(self, args, cwd=None, env=None, stdout=None, stderr=None):
+        self.args = args
+        self.cwd = cwd
+        self.env = env
+        self.stdout = stdout
+        self.stderr = stderr
+        self.terminated = False
+        self.wait_calls = 0
+        type(self).instances.append(self)
+
+    def wait(self):
+        self.wait_calls += 1
+        return 0
+
+    def terminate(self):
+        self.terminated = True
+
+
+class _InterruptServerWaitPopen(_FakePopen):
+    """Popen double modeling a single Ctrl+C interrupting the server wait.
+
+    Only the first ``wait()`` on the uvicorn server process raises; subsequent
+    waits (including the frontend's) return 0, mirroring realistic behaviour
+    where terminate() lets the cleanup waits complete.
+    """
+
+    def wait(self):
+        self.wait_calls += 1
+        if self.wait_calls == 1 and "uvicorn" in self.args:
+            raise KeyboardInterrupt
+        return 0
+
+
+# --- module surface --------------------------------------------------------
+
+
+def test_sdk_cli_module_importable():
+    """SDK CLI module exposes the expected callables."""
+    assert callable(sdk_cli.main)
+    assert callable(sdk_cli.run_seed)
+    assert callable(sdk_cli.run_serve)
+    assert callable(sdk_cli.run_demo)
+
+
+# --- main() argument dispatch ---------------------------------------------
+
+
+def test_sdk_main_seed_dispatches(monkeypatch):
+    calls = []
+
+    def fake_run_seed():
+        calls.append("seed")
+        return 0
+
+    monkeypatch.setattr(sdk_cli, "run_seed", fake_run_seed)
+    monkeypatch.setattr(sys, "argv", ["peaky-peek", "seed"])
+    assert sdk_cli.main() == 0
+    assert calls == ["seed"]
+
+
+def test_sdk_main_serve_dispatches(monkeypatch):
+    calls = []
+
+    def fake_run_serve():
+        calls.append("serve")
+        return 0
+
+    monkeypatch.setattr(sdk_cli, "run_serve", fake_run_serve)
+    monkeypatch.setattr(sys, "argv", ["peaky-peek", "serve"])
+    assert sdk_cli.main() == 0
+    assert calls == ["serve"]
+
+
+def test_sdk_main_demo_dispatches(monkeypatch):
+    calls = []
+
+    def fake_run_demo():
+        calls.append("demo")
+        return 0
+
+    monkeypatch.setattr(sdk_cli, "run_demo", fake_run_demo)
+    monkeypatch.setattr(sys, "argv", ["peaky-peek", "demo"])
+    assert sdk_cli.main() == 0
+    assert calls == ["demo"]
+
+
+def test_sdk_main_no_args_prints_help_and_returns_zero(capsys, monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["peaky-peek"])
+    result = sdk_cli.main()
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "usage:" in captured.out.lower()
+    assert "peaky-peek" in captured.out
+
+
+def test_sdk_main_unknown_command_exits_nonzero(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["peaky-peek", "nope"])
+    with pytest.raises(SystemExit) as exc:
+        sdk_cli.main()
+    assert exc.value.code != 0
+    err = capsys.readouterr().err
+    assert "invalid choice" in err
+
+
+# --- run_seed() ------------------------------------------------------------
+
+
+def test_run_seed_success(monkeypatch, capsys):
+    captured = {}
+
+    def fake_run(cmd, *args, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(sdk_cli, "Path", _make_fake_path(exists_return=True))
+    monkeypatch.setattr(sdk_cli.subprocess, "run", fake_run)
+
+    assert sdk_cli.run_seed() == 0
+
+    out = capsys.readouterr().out
+    assert "Seeding demo sessions" in out
+    assert captured["cmd"][0] == sys.executable
+    assert captured["cmd"][1].endswith("seed_demo_sessions.py")
+
+
+def test_run_seed_propagates_nonzero_returncode(monkeypatch):
+    def fake_run(cmd, *args, **kwargs):
+        return subprocess.CompletedProcess(cmd, 3)
+
+    monkeypatch.setattr(sdk_cli, "Path", _make_fake_path(exists_return=True))
+    monkeypatch.setattr(sdk_cli.subprocess, "run", fake_run)
+
+    assert sdk_cli.run_seed() == 3
+
+
+def test_run_seed_missing_script_returns_one(monkeypatch, capsys):
+    def boom(cmd, *args, **kwargs):
+        raise AssertionError("subprocess.run must not be called when script is missing")
+
+    monkeypatch.setattr(sdk_cli, "Path", _make_fake_path(exists_return=False))
+    monkeypatch.setattr(sdk_cli.subprocess, "run", boom)
+
+    assert sdk_cli.run_seed() == 1
+    err = capsys.readouterr().err
+    assert "seed script not found" in err
+
+
+# --- run_serve() -----------------------------------------------------------
+
+
+def test_run_serve_success(monkeypatch, capsys):
+    captured = {}
+
+    def fake_run(cmd, *args, **kwargs):
+        captured["cmd"] = cmd
+        captured["check"] = kwargs.get("check")
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(sdk_cli.subprocess, "run", fake_run)
+
+    assert sdk_cli.run_serve() == 0
+
+    out = capsys.readouterr().out
+    assert "Starting server" in out
+    assert "localhost:8000" in out
+    assert captured["check"] is True
+    assert "uvicorn" in captured["cmd"]
+    assert "api.main:app" in captured["cmd"]
+
+
+def test_run_serve_keyboard_interrupt_returns_zero(monkeypatch, capsys):
+    def fake_run(cmd, *args, **kwargs):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(sdk_cli.subprocess, "run", fake_run)
+
+    assert sdk_cli.run_serve() == 0
+    out = capsys.readouterr().out
+    assert "Server stopped" in out
+
+
+def test_run_serve_called_process_error_returns_one(monkeypatch, capsys):
+    def fake_run(cmd, *args, **kwargs):
+        raise subprocess.CalledProcessError(returncode=1, cmd=cmd)
+
+    monkeypatch.setattr(sdk_cli.subprocess, "run", fake_run)
+
+    assert sdk_cli.run_serve() == 1
+    err = capsys.readouterr().err
+    assert "Error starting server" in err
+
+
+def test_run_serve_file_not_found_returns_one(monkeypatch, capsys):
+    def fake_run(cmd, *args, **kwargs):
+        raise FileNotFoundError("uvicorn")
+
+    monkeypatch.setattr(sdk_cli.subprocess, "run", fake_run)
+
+    assert sdk_cli.run_serve() == 1
+    err = capsys.readouterr().err
+    assert "uvicorn not found" in err
+
+
+# --- run_demo() ------------------------------------------------------------
+
+
+def test_run_demo_success(monkeypatch, capsys):
+    _FakePopen.instances = []
+
+    monkeypatch.setattr(sdk_cli, "run_seed", lambda: 0)
+    monkeypatch.setattr(sdk_cli.subprocess, "Popen", _FakePopen)
+
+    assert sdk_cli.run_demo() == 0
+
+    out = capsys.readouterr().out
+    assert "Peaky Peek demo is running!" in out
+    assert "http://localhost:8000" in out
+    assert "http://localhost:5173" in out
+
+    # Two background processes spawned: server then frontend.
+    assert len(_FakePopen.instances) == 2
+    server_proc, frontend_proc = _FakePopen.instances
+    assert "uvicorn" in server_proc.args
+    assert "api.main:app" in server_proc.args
+    assert frontend_proc.cwd is not None
+    assert frontend_proc.env.get("API_PORT") == "8000"
+    assert frontend_proc.args == ["npm", "run", "dev"]
+
+
+def test_run_demo_seed_failure_short_circuits(monkeypatch):
+    _FakePopen.instances = []
+
+    def boom(*args, **kwargs):
+        raise AssertionError("Popen must not be called when seeding fails")
+
+    monkeypatch.setattr(sdk_cli, "run_seed", lambda: 7)
+    monkeypatch.setattr(sdk_cli.subprocess, "Popen", boom)
+
+    assert sdk_cli.run_demo() == 7
+    assert _FakePopen.instances == []
+
+
+def test_run_demo_server_popen_failure_returns_one(monkeypatch, capsys):
+    def boom(*args, **kwargs):
+        raise OSError("cannot spawn")
+
+    monkeypatch.setattr(sdk_cli, "run_seed", lambda: 0)
+    monkeypatch.setattr(sdk_cli.subprocess, "Popen", boom)
+
+    assert sdk_cli.run_demo() == 1
+    err = capsys.readouterr().err
+    assert "Error starting server" in err
+
+
+def test_run_demo_frontend_popen_failure_terminates_server(monkeypatch, capsys):
+    _FakePopen.instances = []
+    calls = {"n": 0}
+
+    def popen_factory(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return _FakePopen(*args, **kwargs)
+        raise OSError("npm missing")
+
+    monkeypatch.setattr(sdk_cli, "run_seed", lambda: 0)
+    monkeypatch.setattr(sdk_cli.subprocess, "Popen", popen_factory)
+
+    assert sdk_cli.run_demo() == 1
+    err = capsys.readouterr().err
+    assert "Error starting frontend" in err
+
+    # The server process that did start must be terminated when frontend fails.
+    assert len(_FakePopen.instances) == 1
+    assert _FakePopen.instances[0].terminated is True
+
+
+def test_run_demo_keyboard_interrupt_terminates_both(monkeypatch, capsys):
+    _FakePopen.instances = []
+
+    monkeypatch.setattr(sdk_cli, "run_seed", lambda: 0)
+    monkeypatch.setattr(sdk_cli.subprocess, "Popen", _InterruptServerWaitPopen)
+
+    assert sdk_cli.run_demo() == 0
+    out = capsys.readouterr().out
+    assert "Stopping server and frontend" in out
+
+    assert len(_FakePopen.instances) == 2
+    assert all(p.terminated for p in _FakePopen.instances)

--- a/tests/test_violation_routes.py
+++ b/tests/test_violation_routes.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timezone
 
 import pytest
 from fastapi.routing import APIRoute
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 import api.main as api_main
+import api.violation_routes as violation_routes
 from agent_debugger_sdk.core.context import configure_event_pipeline
+from agent_debugger_sdk.core.events import EventType, Session, SessionStatus, TraceEvent
 from api import app_context
 from api import services as api_services
 from benchmarks import run_evidence_grounding_session
@@ -939,3 +942,302 @@ def test_violation_routes_empty_database(api_repo_factory):
     assert "clusters" in results["cluster"]
     assert "violations" in results["search"]
     assert "sparse_failures" in results["sparse"]
+
+
+# =============================================================================
+# Coverage gap tests: exception branches, explicit session_ids, dashboard
+# analysis block, and multi-session similar-session comparison.
+# =============================================================================
+
+def _make_session(
+    session_id: str,
+    agent_name: str = "coverage_agent",
+    framework: str = "pytest",
+    status: SessionStatus = SessionStatus.COMPLETED,
+) -> Session:
+    return Session(
+        id=session_id,
+        agent_name=agent_name,
+        framework=framework,
+        started_at=datetime(2026, 3, 26, 10, 0, tzinfo=timezone.utc),
+        ended_at=datetime(2026, 3, 26, 11, 0, tzinfo=timezone.utc),
+        status=status,
+        total_cost_usd=0.10,
+        total_tokens=100,
+        llm_calls=1,
+        tool_calls=1,
+        config={"mode": "coverage"},
+        tags=["violation-coverage"],
+    )
+
+
+def _make_event(
+    session_id: str,
+    event_type: EventType,
+    name: str = "cov_event",
+    *,
+    data: dict | None = None,
+) -> TraceEvent:
+    return TraceEvent(
+        session_id=session_id,
+        event_type=event_type,
+        name=name,
+        data=data or {},
+        importance=0.5,
+    )
+
+
+def _patch_loader_to_fail_for(monkeypatch, bad_ids: set[str]) -> None:
+    """Patch load_session_artifacts so it raises for session_ids in bad_ids.
+
+    The real loader returns empty results (not raises) for missing sessions, so
+    the routes' ``except Exception: continue`` branches can only be exercised by
+    forcing a raise.
+    """
+    real = violation_routes.load_session_artifacts
+
+    async def patched(repo, session_id):  # type: ignore[no-untyped-def]
+        if session_id in bad_ids:
+            raise RuntimeError(f"forced load failure for {session_id}")
+        return await real(repo, session_id)
+
+    monkeypatch.setattr(violation_routes, "load_session_artifacts", patched)
+
+
+def _seed_two_sessions(api_repo_factory, prefix: str, agent_name: str = "coverage_agent") -> tuple[str, str]:
+    """Create two sessions each with an ERROR + AGENT_TURN event sharing a name."""
+    sid_a = f"{prefix}-a"
+    sid_b = f"{prefix}-b"
+
+    async def seed() -> None:
+        async with api_repo_factory() as session:
+            repo = TraceRepository(session)
+            await repo.create_session(_make_session(sid_a, agent_name=agent_name))
+            await repo.add_event(_make_event(sid_a, EventType.ERROR, name="unsafe data handling"))
+            await repo.add_event(_make_event(sid_a, EventType.AGENT_TURN, name="turn"))
+            await repo.create_session(_make_session(sid_b, agent_name=agent_name))
+            await repo.add_event(_make_event(sid_b, EventType.ERROR, name="unsafe data handling"))
+            await repo.add_event(_make_event(sid_b, EventType.AGENT_TURN, name="turn"))
+            await session.commit()
+
+    asyncio.run(seed())
+    return sid_a, sid_b
+
+
+def _seed_extra_session(api_repo_factory, session_id: str, *, with_error: bool = True) -> None:
+    """Create one additional session with a turn event (and optional error)."""
+
+    async def seed() -> None:
+        async with api_repo_factory() as session:
+            repo = TraceRepository(session)
+            await repo.create_session(_make_session(session_id))
+            if with_error:
+                await repo.add_event(_make_event(session_id, EventType.ERROR, name="unsafe data handling"))
+            await repo.add_event(_make_event(session_id, EventType.TOOL_CALL, name="search_tool"))
+            await session.commit()
+
+    asyncio.run(seed())
+
+
+# -----------------------------------------------------------------------------
+# POST /api/violations/cluster -- except branch (lines 90-92)
+# -----------------------------------------------------------------------------
+
+def test_cluster_sessions_skips_session_that_fails_to_load(api_repo_factory, monkeypatch):
+    """A session whose load raises is skipped; remaining sessions still cluster."""
+    sid_a, sid_b = _seed_two_sessions(api_repo_factory, prefix="cl-fail")
+    _patch_loader_to_fail_for(monkeypatch, {sid_b})
+
+    cluster_endpoint = _get_route_endpoint("/api/violations/cluster", "POST")
+
+    async def run():
+        async with api_repo_factory() as session:
+            repo = TraceRepository(session)
+            return await cluster_endpoint(
+                session_ids=[sid_a, sid_b],
+                similarity_threshold=0.5,
+                min_cluster_size=2,
+                repo=repo,
+            )
+
+    data = asyncio.run(run())
+    assert "clusters" in data
+    assert "global_outliers" in data
+    # sid_a loaded; sid_b skipped via the except branch
+    assert data["total_sessions_analyzed"] == 1
+
+
+# -----------------------------------------------------------------------------
+# POST /api/violations/search -- explicit session_ids (154) + except (169-171)
+# -----------------------------------------------------------------------------
+
+def test_search_violations_with_explicit_session_ids(api_repo_factory):
+    """Explicit session_ids branch is exercised and matches found."""
+    sid_a, sid_b = _seed_two_sessions(api_repo_factory, prefix="src-ids")
+    search_endpoint = _get_route_endpoint("/api/violations/search", "POST")
+
+    async def run():
+        async with api_repo_factory() as session:
+            repo = TraceRepository(session)
+            return await search_endpoint(
+                nl_query="unsafe data handling",
+                session_ids=[sid_a, sid_b],
+                max_results=10,
+                repo=repo,
+            )
+
+    data = asyncio.run(run())
+    assert data["query"] == "unsafe data handling"
+    assert data["total_sessions_searched"] == 2
+    assert isinstance(data["violations"], list)
+    # event names contain the query keywords -> at least one violation per session
+    assert data["total_violations_found"] >= 1
+
+
+def test_search_violations_skips_session_that_fails_to_load(api_repo_factory, monkeypatch):
+    """A session whose load raises is skipped during search."""
+    sid_a, sid_b = _seed_two_sessions(api_repo_factory, prefix="src-fail")
+    _patch_loader_to_fail_for(monkeypatch, {sid_b})
+    search_endpoint = _get_route_endpoint("/api/violations/search", "POST")
+
+    async def run():
+        async with api_repo_factory() as session:
+            repo = TraceRepository(session)
+            return await search_endpoint(
+                nl_query="unsafe",
+                session_ids=[sid_a, sid_b],
+                max_results=10,
+                repo=repo,
+            )
+
+    data = asyncio.run(run())
+    assert data["total_sessions_searched"] == 1
+    assert isinstance(data["violations"], list)
+
+
+# -----------------------------------------------------------------------------
+# GET /api/violations/sparse -- explicit session_ids (223) + except (238-240)
+# -----------------------------------------------------------------------------
+
+def test_detect_sparse_failures_with_explicit_session_ids(api_repo_factory):
+    """Explicit session_ids branch for sparse failures is exercised."""
+    sid_a, sid_b = _seed_two_sessions(api_repo_factory, prefix="sp-ids")
+    sparse_endpoint = _get_route_endpoint("/api/violations/sparse", "GET")
+
+    async def run():
+        async with api_repo_factory() as session:
+            repo = TraceRepository(session)
+            return await sparse_endpoint(
+                session_ids=[sid_a, sid_b],
+                min_occurrences=2,
+                repo=repo,
+            )
+
+    data = asyncio.run(run())
+    assert data["min_occurrences"] == 2
+    assert data["total_sessions_analyzed"] == 2
+    # both sessions have an ERROR event -> identical pattern key -> pattern found
+    assert data["total_patterns_found"] >= 1
+    for failure in data["sparse_failures"]:
+        assert isinstance(failure["failure_type"], str)
+        assert sid_a in failure["session_ids"]
+        assert sid_b in failure["session_ids"]
+
+
+def test_detect_sparse_failures_skips_session_that_fails_to_load(api_repo_factory, monkeypatch):
+    """A session whose load raises is skipped during sparse failure detection."""
+    sid_a, sid_b = _seed_two_sessions(api_repo_factory, prefix="sp-fail")
+    _patch_loader_to_fail_for(monkeypatch, {sid_b})
+    sparse_endpoint = _get_route_endpoint("/api/violations/sparse", "GET")
+
+    async def run():
+        async with api_repo_factory() as session:
+            repo = TraceRepository(session)
+            return await sparse_endpoint(
+                session_ids=[sid_a, sid_b],
+                min_occurrences=2,
+                repo=repo,
+            )
+
+    data = asyncio.run(run())
+    assert data["total_sessions_analyzed"] == 1
+
+
+# -----------------------------------------------------------------------------
+# GET /api/violations/dashboard -- load loop (317-321) + analysis (343-387)
+# -----------------------------------------------------------------------------
+
+def test_dashboard_runs_full_analysis_when_sessions_present(api_repo_factory):
+    """Dashboard load loop and full analysis block execute with sessions present."""
+    sid_a, sid_b = _seed_two_sessions(api_repo_factory, prefix="dash")
+    _seed_extra_session(api_repo_factory, "dash-c", with_error=True)
+
+    dashboard_endpoint = _get_route_endpoint("/api/violations/dashboard", "GET")
+
+    async def run():
+        async with api_repo_factory() as session:
+            repo = TraceRepository(session)
+            return await dashboard_endpoint(days=7, repo=repo)
+
+    data = asyncio.run(run())
+    assert data["total_sessions_analyzed"] >= 1
+    assert data["time_range_days"] == 7
+    # The post-analysis return shape (lines 387-408) only runs when sessions exist
+    assert "generated_at" in data
+    assert "average_cluster_size" in data["cluster_summary"]
+    assert isinstance(data["sparse_failure_summary"]["most_common_failure_types"], list)
+    assert isinstance(data["violation_summary"]["by_type"], dict)
+    assert isinstance(data["violation_summary"]["by_severity"], dict)
+    # three sessions each have an ERROR event -> sparse pattern detected
+    assert data["sparse_failure_summary"]["total_patterns"] >= 1
+    # events contain "unsafe data handling" -> one of the common queries matches
+    assert data["violation_summary"]["total_violations"] >= 1
+
+
+def test_dashboard_skips_session_that_fails_to_load(api_repo_factory, monkeypatch):
+    """A session whose load raises inside the dashboard loop is skipped."""
+    sid_a, sid_b = _seed_two_sessions(api_repo_factory, prefix="dash-fail")
+    _patch_loader_to_fail_for(monkeypatch, {sid_b})
+    dashboard_endpoint = _get_route_endpoint("/api/violations/dashboard", "GET")
+
+    async def run():
+        async with api_repo_factory() as session:
+            repo = TraceRepository(session)
+            return await dashboard_endpoint(days=7, repo=repo)
+
+    data = asyncio.run(run())
+    # sid_a loaded, sid_b skipped via except branch; analysis still runs
+    assert data["total_sessions_analyzed"] == 1
+    assert "generated_at" in data
+
+
+# -----------------------------------------------------------------------------
+# POST /api/violations/session/{session_id}/similar -- comparison loop (462-475)
+# -----------------------------------------------------------------------------
+
+def test_find_similar_sessions_compares_multiple_other_sessions(api_repo_factory):
+    """The per-other-session comparison loop body executes when other sessions exist."""
+    sid_a, sid_b = _seed_two_sessions(api_repo_factory, prefix="sim")
+    _seed_extra_session(api_repo_factory, "sim-c", with_error=False)
+
+    similar_endpoint = _get_route_endpoint(
+        "/api/violations/session/{session_id}/similar", "POST"
+    )
+
+    async def run():
+        async with api_repo_factory() as session:
+            repo = TraceRepository(session)
+            return await similar_endpoint(session_id=sid_a, limit=10, repo=repo)
+
+    data = asyncio.run(run())
+    assert data["reference_session_id"] == sid_a
+    # two other sessions exist (sid_b, sim-c) -> both compared
+    assert data["total_compared"] == 2
+    assert isinstance(data["similar_sessions"], list)
+    assert len(data["similar_sessions"]) <= 10
+    for entry in data["similar_sessions"]:
+        assert "session_id" in entry
+        assert "agent_name" in entry
+        assert "started_at" in entry
+        assert "similarity_score" in entry
+        assert isinstance(entry["similarity_score"], (int, float))


### PR DESCRIPTION
## Summary

Repairs `scripts/hooks/check_duplicate_queries.py` — the PreToolUse hook that blocks edits introducing duplicate SQLAlchemy query patterns. Three latent defects combined to leave it unable to deny duplicate queries.

## Bugs fixed

1. **Double-offset in `extract_query_shapes`** — `remaining = content[start:]` already shifted the window, then `remaining[start:]` shifted it again (`content[2*start:]`). For any `select()` not at the very start of the content, the `.where()` clause immediately following fell inside the skipped region and was never matched. This is the pre-existing defect Copilot flagged during review of #275.

2. **`main()` deny path crashed with `KeyError`** — `check_duplicates()` returns a dict `{"duplicates": [...], "shapes_found": [...]}`, but `main()` did `duplicates[0]`, indexing the dict with `0`. The deny branch always crashed with a traceback instead of emitting the `{"decision": "deny", ...}` JSON the hook contract requires. The hook effectively never denied cleanly.

3. **Wrong return annotation** — `check_duplicates` was annotated `-> list[dict]` despite returning a dict, masking the indexing defect from type checking. Modeled with a `TypedDict` (`DuplicateCheck`).

## Tests

New `tests/test_check_duplicate_queries.py` (8 tests):
- leading `select()` extraction (baseline)
- **non-leading `select()` extraction** (the regression — fails before the fix)
- unknown model still extracted but not flagged
- multi-condition `.where()` field names sorted alphabetically
- `check_duplicates` flags a known pattern
- `check_duplicates` allows unknown patterns
- `main()` denies an in-scope duplicate path
- `main()` allows an out-of-scope path

## Validation

- `ruff check` clean on both files
- New test file: 8/8 passing
- Full suite: 3037 passed, 19 skipped, 0 failures (no regression)

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
