### PR TITLE
chore: explicit conversion flags, dict.get, direct attr access (RUF010/RUF019/B009)

### DIFF
--- a/agent_debugger_sdk/core/emitter.py
+++ b/agent_debugger_sdk/core/emitter.py
@@ -75,7 +75,7 @@ class EventEmitter:
             return
         try:
             if is_method:
-                await getattr(target, "publish")(*args)
+                await getattr(target, "publish")(*args)  # noqa: B009  # duck-typed dispatch on `object` target
             else:
                 await target(args)
         except Exception as e:

--- a/api/reasoning_routes.py
+++ b/api/reasoning_routes.py
@@ -486,7 +486,7 @@ async def import_scenario(
     try:
         imported_branch = editor.import_scenario(scenario_data)
     except (ValueError, KeyError) as e:
-        raise HTTPException(status_code=400, detail=f"Invalid scenario data: {str(e)}") from e
+        raise HTTPException(status_code=400, detail=f"Invalid scenario data: {e!s}") from e
 
     return {
         "session_id": session_id,
@@ -532,10 +532,11 @@ def _event_to_dict(event: TraceEvent) -> dict[str, Any]:
     event_dict = event.to_dict()
 
     # Handle datetime serialization
-    if "timestamp" in event_dict and event_dict["timestamp"]:
-        if hasattr(event_dict["timestamp"], "isoformat"):
-            event_dict["timestamp"] = event_dict["timestamp"].isoformat()
+    timestamp = event_dict.get("timestamp")
+    if timestamp:
+        if hasattr(timestamp, "isoformat"):
+            event_dict["timestamp"] = timestamp.isoformat()
         else:
-            event_dict["timestamp"] = str(event_dict["timestamp"])
+            event_dict["timestamp"] = str(timestamp)
 
     return event_dict

--- a/storage/embedding.py
+++ b/storage/embedding.py
@@ -236,8 +236,9 @@ def build_session_embedding(events: list[dict[str, Any]]) -> dict[str, float]:
     text_parts = []
     for event in events:
         for field in ["event_type", "name", "error_type", "error_message", "tool_name", "model"]:
-            if field in event and event[field]:
-                text_parts.append(str(event[field]))
+            value = event.get(field)
+            if value:
+                text_parts.append(str(value))
 
     # Combine all text parts
     combined_text = " ".join(text_parts)

--- a/tests/test_checkpoint_restore.py
+++ b/tests/test_checkpoint_restore.py
@@ -169,7 +169,7 @@ class TestTraceContextRestore:
         from agent_debugger_sdk import TraceContext
 
         assert hasattr(TraceContext, "restore")
-        assert callable(getattr(TraceContext, "restore"))
+        assert callable(TraceContext.restore)
 
     @pytest.mark.asyncio
     async def test_restore_creates_context_with_restored_state(self):


### PR DESCRIPTION
## Summary

Continuation of the lint-modernization chore series (B904 #274, C4/PIE790 #275, hook fix #276). Applies 4 safe behavior-preserving ruff simplifications surfaced via explicit rule selection — the repo's lint config is `E/F/I` only, so these only appear when `--select`-ed.

## Changes

- **api/reasoning_routes.py**
  - RUF010: `f"...{str(e)}"` → `f"...{e!s}"` (explicit conversion flag, identical output)
  - RUF019: `if "timestamp" in event_dict and event_dict["timestamp"]` → `if event_dict.get("timestamp")` (identical truthiness)
- **storage/embedding.py**
  - RUF019: `if field in event and event[field]` → `if event.get(field)` (param typed `list[dict[str, Any]]`)
- **tests/test_checkpoint_restore.py**
  - B009: `getattr(TraceContext, "restore")` → `TraceContext.restore` (direct attribute access)

### Deliberately excluded

`agent_debugger_sdk/core/emitter.py` had one B009 hit (`getattr(target, "publish")`). Left as-is with an explanatory `# noqa: B009`: `target` is typed `object | None` for intentional duck-typed dispatch (callback-or-method holder), so direct `target.publish` would be a false-positive regression on loose typing. Same judgment-call class as prior PIE807/UP037 exclusions.

## Validation

- `ruff check .` clean (E/F/I)
- `ruff check --select RUF010,RUF019,B009` → 0
- pytest: 5 pre-existing failures in `tests/api/test_cross_session_routes.py` reproduce on clean `origin/main` (stashed diff → still 5 failed) — they are an unrelated offset-naive/aware `datetime` bug in `collector/clustering/cross_session.py:171`, **not** introduced by this PR.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
