### PR TITLE
fix: normalize tz-naive session timestamps in cross-session clustering

### DIFF
--- a/collector/clustering/cross_session.py
+++ b/collector/clustering/cross_session.py
@@ -13,6 +13,18 @@ from typing import Any
 from agent_debugger_sdk.core.events import Session
 
 
+def _to_aware_utc(ts: datetime) -> datetime:
+    """Attach UTC tzinfo to naive datetimes so they compare safely with now().
+
+    Persisted session timestamps are frequently naive UTC; mixing them with the
+    tz-aware datetime.now(timezone.utc) used throughout this module raises
+    ``TypeError`` on subtraction or min/max. Coerce once at every arithmetic site.
+    """
+    if ts.tzinfo is None:
+        return ts.replace(tzinfo=timezone.utc)
+    return ts
+
+
 @dataclass
 class CrossSessionCluster:
     """Represents a cluster of similar failures across multiple sessions.
@@ -107,7 +119,7 @@ class CrossSessionClusterAnalyzer:
                 data = fingerprint_data[fingerprint]
                 data["sessions"].append(session.id)
                 data["scores"].append(score)
-                data["timestamps"].append(session.started_at)
+                data["timestamps"].append(_to_aware_utc(session.started_at))
 
         # Build clusters with time-decay weighting
         clusters: list[CrossSessionCluster] = []
@@ -168,7 +180,7 @@ class CrossSessionClusterAnalyzer:
 
         for ts, score in zip(timestamps, scores):
             # Calculate age in days
-            age_days = (now - ts).total_seconds() / 86400.0
+            age_days = (now - _to_aware_utc(ts)).total_seconds() / 86400.0
 
             # Exponential decay weight
             decay_factor = math.exp(-age_days / self.decay_half_life_days)
@@ -185,11 +197,11 @@ class CrossSessionClusterAnalyzer:
     def _is_recent(self, timestamp: datetime) -> bool:
         """Check if a timestamp is within the recent window."""
         now = datetime.now(timezone.utc)
-        age_days = (now - timestamp).total_seconds() / 86400.0
+        age_days = (now - _to_aware_utc(timestamp)).total_seconds() / 86400.0
         return age_days <= self.RECENT_SESSION_DAYS
 
     def _is_stale(self, timestamp: datetime) -> bool:
         """Check if a timestamp is beyond the stale threshold."""
         now = datetime.now(timezone.utc)
-        age_days = (now - timestamp).total_seconds() / 86400.0
+        age_days = (now - _to_aware_utc(timestamp)).total_seconds() / 86400.0
         return age_days >= self.STALE_SESSION_DAYS

--- a/tests/test_cross_session_clustering.py
+++ b/tests/test_cross_session_clustering.py
@@ -341,3 +341,74 @@ def test_similar_tool_detection():
     # Edge cases
     assert _tools_are_similar("", "search") is False
     assert _tools_are_similar("abc", "def") is False
+
+
+def test_analyze_handles_naive_session_timestamps():
+    """Regression: naive (storage-loaded) started_at must not crash analyze().
+
+    Timestamps loaded from sqlite/aiosqlite are tz-naive; mixing them with the
+    tz-aware datetime.now(timezone.utc) in analyze()/min/max previously raised
+    ``TypeError: can't subtract offset-naive and offset-aware datetimes``.
+    """
+    naive_now = datetime.now(timezone.utc).replace(tzinfo=None)  # mimics storage
+    analyzer = CrossSessionClusterAnalyzer()
+
+    sessions = [
+        create_test_session("session-1", naive_now - timedelta(days=1)),
+        create_test_session("session-2", naive_now),
+    ]
+    session_rankings = {
+        "session-1": {"failure_fingerprints": [("error:timeout", 0.8)], "replay_value": 0.5},
+        "session-2": {"failure_fingerprints": [("error:timeout", 0.9)], "replay_value": 0.5},
+    }
+
+    clusters = analyzer.analyze(sessions, session_rankings)
+
+    assert len(clusters) == 1
+    cluster = clusters[0]
+    assert cluster.count == 2
+    assert cluster.score > 0.0
+    # Normalized timestamps are tz-aware UTC, so min/max and isoformat work cleanly.
+    assert cluster.first_seen.tzinfo is not None
+    assert cluster.last_seen.tzinfo is not None
+
+
+def test_analyze_handles_mixed_naive_and_aware_timestamps():
+    """Regression: a mix of naive + aware started_at must not crash min/max."""
+    analyzer = CrossSessionClusterAnalyzer()
+    sessions = [
+        create_test_session(
+            "naive", datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=1)
+        ),
+        create_test_session("aware", datetime.now(timezone.utc)),
+    ]
+    session_rankings = {
+        "naive": {"failure_fingerprints": [("error:timeout", 0.8)], "replay_value": 0.5},
+        "aware": {"failure_fingerprints": [("error:timeout", 0.9)], "replay_value": 0.5},
+    }
+
+    clusters = analyzer.analyze(sessions, session_rankings)
+
+    assert len(clusters) == 1
+    assert clusters[0].count == 2
+
+
+def test_time_decay_score_handles_naive_timestamps():
+    """Regression: _compute_time_decay_score must not crash on naive timestamps."""
+    analyzer = CrossSessionClusterAnalyzer()
+    naive_ts = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=2)
+
+    score = analyzer._compute_time_decay_score([naive_ts], [0.5])
+
+    assert 0.0 <= score <= 1.0
+
+
+def test_recent_and_stale_checks_handle_naive_timestamps():
+    """Regression: _is_recent / _is_stale must not crash on naive timestamps."""
+    analyzer = CrossSessionClusterAnalyzer()
+    naive_recent = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=1)
+    naive_stale = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=60)
+
+    assert analyzer._is_recent(naive_recent) is True
+    assert analyzer._is_stale(naive_stale) is True
+


### PR DESCRIPTION
## Summary

`CrossSessionClusterAnalyzer` mixed tz-aware `datetime.now(timezone.utc)` with session timestamps that arrive **tz-naive** from storage (sqlite/aiosqlite, and any backend that drops tzinfo). The resulting `now - ts` subtraction — and the `min()`/`max()` over timestamps in `analyze()` — raised:

```
TypeError: can't subtract offset-naive and offset-aware datetimes
```

at `collector/clustering/cross_session.py`, crashing `GET /api/clusters` for any non-empty failure set loaded from the repository.

## Root cause

`now = datetime.now(timezone.utc)` is tz-aware, but `Session.started_at` loaded from sqlite is tz-naive. Four sites did `now - ts` and one pair did `min()/max()` over the timestamps — all crash on a naive/aware mix.

## Fix

Added `_to_aware_utc(ts)` (mirrors the existing `api/session_routes._normalize_datetime` pattern) and applied it at every affected site:
- `analyze()` ingestion — normalizes before the `min()/max()` bounds
- `_compute_time_decay_score()` — the `now - ts` subtraction
- `_is_recent()` / `_is_stale()` — the `now - ts` subtraction

## Why this stayed latent

`tests/api/test_cross_session_routes.py` documents this exact bug and worked around it by stubbing `_compute_time_decay_score` (`_stub_time_decay_score`). The analyzer's own tests (`tests/test_cross_session_clustering.py`) used in-memory tz-aware sessions, so the defect never surfaced. The docstring's `BUG:` note can be retired after this lands.

## Tests

4 regression tests added covering:
- naive session timestamps through full `analyze()`
- mixed naive + aware timestamps through `analyze()` (the `min/max` case)
- `_compute_time_decay_score()` with a naive timestamp
- `_is_recent()` / `_is_stale()` with naive timestamps

## Validation

- `ruff check .` clean
- `pytest -q`: 3033 passed, 19 skipped, 0 failed (includes the 4 new tests)
- Direct repro (`_compute_time_decay_score([naive_ts], [0.5])`) returns `0.5` instead of raising `TypeError`

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)