### PR TITLE
chore: annotate mutable class constants with ClassVar (RUF012) + next(iter()) (RUF015)

### DIFF
--- a/api/middleware.py
+++ b/api/middleware.py
@@ -6,6 +6,7 @@ import logging
 import uuid
 from collections.abc import Callable
 from time import perf_counter
+from typing import ClassVar
 
 from fastapi import Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -87,7 +88,7 @@ class ContentTypeValidationMiddleware(BaseHTTPMiddleware):
     """
 
     # Paths that require JSON Content-Type for POST/PUT
-    JSON_ENDPOINTS = {
+    JSON_ENDPOINTS: ClassVar[set[str]] = {
         "/api/sessions/{session_id}",
         "/api/checkpoints/{checkpoint_id}/restore",
         "/api/sessions/{session_id}/fix-note",
@@ -95,7 +96,7 @@ class ContentTypeValidationMiddleware(BaseHTTPMiddleware):
     }
 
     # SSE endpoints that require text/event-stream Accept header
-    SSE_ENDPOINTS = {
+    SSE_ENDPOINTS: ClassVar[set[str]] = {
         "/api/sessions/{session_id}/stream",
     }
 

--- a/storage/entities.py
+++ b/storage/entities.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import re
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, ClassVar
 
 
 @dataclass
@@ -59,7 +59,7 @@ class EntityExtractor:
     """
 
     # Patterns for extracting API endpoints from tool names or arguments
-    API_ENDPOINT_PATTERNS = [
+    API_ENDPOINT_PATTERNS: ClassVar[list[re.Pattern[str]]] = [
         re.compile(r"https?://[^\s\"'<>]+", re.IGNORECASE),
         re.compile(r"/[a-z_]+/[a-z_]+", re.IGNORECASE),
         re.compile(r"[a-z]+\.[a-z]+\.[a-z]+", re.IGNORECASE),

--- a/storage/repositories/alert_repo.py
+++ b/storage/repositories/alert_repo.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import Any, ClassVar
 
 from sqlalchemy import and_, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -26,7 +26,7 @@ class AnomalyAlertRepository:
     - ix_anomaly_alerts_tenant_id_status: tenant + status filtering
     """
 
-    VALID_STATUSES = {"active", "acknowledged", "resolved", "dismissed"}
+    VALID_STATUSES: ClassVar[set[str]] = {"active", "acknowledged", "resolved", "dismissed"}
 
     # Class-level cache shared across instances (for summary/trending data)
     _cache = QueryCache()

--- a/storage/search.py
+++ b/storage/search.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import re
 from datetime import datetime
-from typing import Any
+from typing import Any, ClassVar
 
 from sqlalchemy import String, cast, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -57,7 +57,7 @@ class SessionSearchService:
     """
 
     # Natural language query patterns
-    NL_PATTERNS = {
+    NL_PATTERNS: ClassVar[dict[str, dict[str, str | int]]] = {
         "stuck in a loop": {"min_errors": 1, "query": "loop repeat retry again"},
         "tool execution failures": {"event_type": "tool_result", "query": "tool error failed"},
         "llm errors": {"event_type": "error", "query": "llm error api rate limit"},
@@ -73,7 +73,7 @@ class SessionSearchService:
         re.compile(r'\bagent\s+["\']([^"\']+)["\']', re.IGNORECASE),
         re.compile(r"\bagent\s+([\w-]+)\b", re.IGNORECASE),
     )
-    AGENT_NAME_STOPWORDS = {
+    AGENT_NAME_STOPWORDS: ClassVar[set[str]] = {
         "a",
         "an",
         "and",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ Covers two related but distinct CLI modules:
 
 import subprocess
 import sys
+from typing import ClassVar
 from unittest.mock import patch
 
 import pytest
@@ -77,7 +78,7 @@ def _make_fake_path(exists_return: bool):
 class _FakePopen:
     """Minimal subprocess.Popen double recording terminate()/wait() calls."""
 
-    instances: list["_FakePopen"] = []
+    instances: ClassVar[list["_FakePopen"]] = []
 
     def __init__(self, args, cwd=None, env=None, stdout=None, stderr=None):
         self.args = args

--- a/tests/test_pattern_detector.py
+++ b/tests/test_pattern_detector.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from typing import ClassVar
 
 import pytest
 
@@ -58,7 +59,7 @@ def _pattern(
 # ---------------------------------------------------------------------------
 
 class TestPatternToDict:
-    EXPECTED_KEYS = {
+    EXPECTED_KEYS: ClassVar[set[str]] = {
         "pattern_type",
         "agent_name",
         "severity",

--- a/tests/test_stepper.py
+++ b/tests/test_stepper.py
@@ -727,7 +727,7 @@ class TestSerialization:
         stepper2.import_state(exported)
 
         assert len(stepper2.branches) == 1
-        imported_branch = list(stepper2.branches.values())[0]
+        imported_branch = next(iter(stepper2.branches.values()))
         assert imported_branch.name == "Test"
 
     def test_import_state_with_invalid_index(self, sample_events):


### PR DESCRIPTION
## Summary

Small behavior-preserving lint cleanup surfaced via explicit `ruff --select` (the repo's configured lint set is E/F/I only, so these surface only when selected).

- **RUF012** (`mutable-class-default`): annotated 8 read-only mutable class attributes — `set` / `dict` / `list` literals used as constants — with `typing.ClassVar[...]`. Pure type-checker signal documenting "class-level constant, not per-instance state"; **zero runtime change**.
- **RUF015** (`unnecessary-iterable-allocation-for-first-element`): replaced `list(x.values())[0]` with `next(iter(x.values()))` for a single-element access already guarded by `assert len == 1`.

## Files

RUF012 (6 files / 8 sites):
- `api/middleware.py` — `JSON_ENDPOINTS`, `SSE_ENDPOINTS`
- `storage/entities.py` — `API_ENDPOINT_PATTERNS`
- `storage/repositories/alert_repo.py` — `VALID_STATUSES`
- `storage/search.py` — `NL_PATTERNS`, `AGENT_NAME_STOPWORDS`
- `tests/test_cli.py` — `_FakePopen.instances` (intentional shared test registry)
- `tests/test_pattern_detector.py` — `EXPECTED_KEYS`

RUF015 (1 site):
- `tests/test_stepper.py`

All target classes verified plain classes (not Pydantic models / dataclasses) so `ClassVar` carries no field-semantics change.

## Validation

- `ruff check --select RUF012,RUF015,I .` → clean
- `ruff check .` (full E/F/I config) → clean
- Affected tests pass: `test_cli.py`, `test_pattern_detector.py`, `test_stepper.py`, `test_cross_session_clustering.py`, `test_query_performance.py`, `test_api_contract.py` (154 passed)

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
