### PR TITLE
chore: collapse needless bool branches and unused loop vars (SIM103/B007/PIE810/SIM110)

### DIFF
--- a/agent_debugger_sdk/auto_patch/frame_capture.py
+++ b/agent_debugger_sdk/auto_patch/frame_capture.py
@@ -108,10 +108,7 @@ class FrameCaptureSession:
 
         # Apply module filters if configured
         if self.config.module_filters:
-            for pattern in self.config.module_filters:
-                if pattern in module_path:
-                    return True
-            return False
+            return any(pattern in module_path for pattern in self.config.module_filters)
 
         return True
 

--- a/agent_debugger_sdk/core/redundancy_scorer.py
+++ b/agent_debugger_sdk/core/redundancy_scorer.py
@@ -55,9 +55,7 @@ def _event_has_error(event: TraceEvent) -> bool:
         return True
     if event.event_type == EventType.POLICY_VIOLATION:
         return True
-    if event.event_type == EventType.BEHAVIOR_ALERT:
-        return True
-    return False
+    return event.event_type == EventType.BEHAVIOR_ALERT
 
 
 def _event_has_downstream_impact(event: TraceEvent, all_events: list[TraceEvent]) -> bool:
@@ -71,11 +69,8 @@ def _event_has_downstream_impact(event: TraceEvent, all_events: list[TraceEvent]
             return True
 
     # Check if this is a decision or tool call that influenced later events
-    if event.event_type in {EventType.DECISION, EventType.TOOL_CALL, EventType.LLM_REQUEST}:
-        # These event types typically have downstream impact by default
-        return True
-
-    return False
+    # These event types typically have downstream impact by default
+    return event.event_type in {EventType.DECISION, EventType.TOOL_CALL, EventType.LLM_REQUEST}
 
 
 def _classify_step_contribution(

--- a/agent_debugger_sdk/core/swimlane.py
+++ b/agent_debugger_sdk/core/swimlane.py
@@ -505,7 +505,7 @@ class CoordinationAnalyzer:
         TIMEOUT_THRESHOLD_SECONDS = 30.0
 
         for lane in self.session.lanes.values():
-            for i, event in enumerate(lane.events):
+            for event in lane.events:
                 if event.event_type == EventType.TOOL_CALL:
                     target_agent = _extract_target_agent(event)
                     if target_agent and target_agent in self.session.lanes:
@@ -616,7 +616,7 @@ class EmergentBehaviorDetector:
             for event in lane.events:
                 if event.event_type == EventType.DECISION:
                     directed_to = _extract_directed_agents(event)
-                    for agent in directed_to:
+                    for _ in directed_to:
                         direction_counts[lane.agent_id] = direction_counts.get(lane.agent_id, 0) + 1
 
         if direction_counts:

--- a/collector/replay.py
+++ b/collector/replay.py
@@ -79,9 +79,7 @@ def matches_breakpoint(
         return True
     if confidence_below is not None and getattr(event, "confidence", 1.0) <= confidence_below:
         return True
-    if safety_outcomes and getattr(event, "outcome", "") in safety_outcomes:
-        return True
-    return False
+    return bool(safety_outcomes and getattr(event, "outcome", "") in safety_outcomes)
 
 
 def _collect_focus_scope_ids(

--- a/scripts/hooks/check_security.py
+++ b/scripts/hooks/check_security.py
@@ -82,10 +82,7 @@ def should_check_file(file_path: Path) -> bool:
         return False
 
     # Check file extension
-    if file_path.suffix.lower() not in CODE_EXTENSIONS:
-        return False
-
-    return True
+    return file_path.suffix.lower() in CODE_EXTENSIONS
 
 
 def check_content(content: str, file_path: Path) -> tuple[bool, list[str]]:

--- a/tests/collector/test_collector_persistence.py
+++ b/tests/collector/test_collector_persistence.py
@@ -149,9 +149,7 @@ def test_resolve_default_storage_path_prefers_writable_path(monkeypatch):
 
     # Mock path checks - make default writable, others not checked
     def mock_is_writable(path):
-        if path == DEFAULT_STORAGE_PATH:
-            return True
-        return False
+        return path == DEFAULT_STORAGE_PATH
 
     manager = PersistenceManager(buffer=buffer)
     manager._is_writable_path = mock_is_writable
@@ -166,9 +164,7 @@ def test_resolve_default_storage_path_falls_back_to_user_path(monkeypatch):
     buffer = MagicMock(spec=EventBuffer)
 
     def mock_is_writable(path):
-        if path == USER_STORAGE_PATH:
-            return True
-        return False
+        return path == USER_STORAGE_PATH
 
     manager = PersistenceManager(buffer=buffer)
     manager._is_writable_path = mock_is_writable
@@ -183,9 +179,7 @@ def test_resolve_default_storage_path_falls_back_to_temp(monkeypatch):
     buffer = MagicMock(spec=EventBuffer)
 
     def mock_is_writable(path):
-        if path == FALLBACK_STORAGE_PATH:
-            return True
-        return False
+        return path == FALLBACK_STORAGE_PATH
 
     manager = PersistenceManager(buffer=buffer)
     manager._is_writable_path = mock_is_writable

--- a/tests/contract/test_schema_alignment.py
+++ b/tests/contract/test_schema_alignment.py
@@ -29,7 +29,7 @@ def _parse_ts_interface_fields(ts_source: str, interface_name: str) -> set[str]:
     for line in body.split("\n"):
         line = line.strip()
         # Skip comment lines and closing braces
-        if not line or line.startswith("//") or line.startswith("}"):
+        if not line or line.startswith(("//", "}")):
             continue
         field_match = re.match(r"^(\w+)(\??):", line)
         if field_match:

--- a/tests/intelligence/test_clustering.py
+++ b/tests/intelligence/test_clustering.py
@@ -89,7 +89,7 @@ class TestCrossSessionClustering:
                     }
                 )
         assert len(all_failure_fingerprints) > 0, "Should have at least one failure cluster"
-        for fingerprint, cluster_data_list in all_failure_fingerprints.items():
+        for _, cluster_data_list in all_failure_fingerprints.items():
             for cluster_data in cluster_data_list:
                 cluster = cluster_data["cluster"]
                 assert "count" in cluster
@@ -101,7 +101,7 @@ class TestCrossSessionClustering:
 
     def test_cluster_representative_selection(self, sample_sessions, intelligence):
         """Verify that representative traces are selected for each cluster."""
-        for session, events, checkpoints in sample_sessions:
+        for _, events, checkpoints in sample_sessions:
             analysis = intelligence.analyze_session(events, checkpoints)
             assert "representative_failure_ids" in analysis
             for cluster in analysis["failure_clusters"]:

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -730,7 +730,7 @@ class TestBenchmarkSessionIntegrity:
         """All events should be serializable via to_dict()."""
         scenarios = iter_seed_scenarios()
 
-        for name, runner in scenarios:
+        for _, runner in scenarios:
             session = await runner()
 
             for event in session.events:

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -209,7 +209,7 @@ class TestConfigConcurrency:
                 results.append(("get", config))
 
         threads = []
-        for i in range(25):
+        for _ in range(25):
             threads.append(threading.Thread(target=call_init))
             threads.append(threading.Thread(target=call_get_config))
 


### PR DESCRIPTION
## Summary

Behavior-preserving ruff simplification batch — 16 sites across 10 files. These rules surface only via explicit `--select` (repo lint config is E/F/I only); all changes are mechanical and behavior-identical, verified by the full test suite.

## Changes

- **SIM103** (8 sites): collapse trailing `if cond: return True` / `return False` → `return cond` in `redundancy_scorer.py` (2), `collector/replay.py`, `scripts/hooks/check_security.py`, and `tests/collector/test_collector_persistence.py` (3 `mock_is_writable` helpers). The `replay.py` site wraps in `bool()` to preserve exact `True`/`False` return semantics across the `set and X` short-circuit. Explanatory comments preserved.
- **B007** (6 sites): drop `enumerate` where the index is unused / rename unused loop-control vars to `_` in `swimlane.py` (2), `tests/intelligence/test_clustering.py` (2), `tests/test_benchmarks.py`, `tests/test_concurrency.py`.
- **PIE810** (1 site): single `startswith(("//", "}"))` call in `tests/contract/test_schema_alignment.py`.
- **SIM110** (1 site): `for`-loop → `any()` in `auto_patch/frame_capture.py` module-filter check.

## Excluded (deliberately, for separate focused PRs)

- **B905** (`zip` without `strict=`) — 8 sites, each needs a per-site `strict=True`/`False` judgment.
- **B023** (loop var bound by function) — 2 sites in `test_violation_routes.py`; potential latent late-binding closure bugs, deserve their own analysis + regression tests.
- **SIM222** (`... or True`) — 1 site in `test_bug_fixes.py` that is actually a vacuous assertion (real test bug), not a mechanical simplification.

## Validation

- `ruff check . --select SIM103,B007,PIE810,SIM110` → All checks passed
- `ruff check .` (full E/F/I config) → All checks passed
- Full pytest suite: **2968 passed, 19 skipped, 0 failed**

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>