### PR TITLE
chore: add explicit strict= to zip() calls (B905)

### DIFF
--- a/agent_debugger_sdk/core/violation_detector.py
+++ b/agent_debugger_sdk/core/violation_detector.py
@@ -137,7 +137,7 @@ class SessionEmbedding:
         v2 = other.embedding_vector[:min_len]
 
         # Cosine similarity
-        dot_product = sum(a * b for a, b in zip(v1, v2))
+        dot_product = sum(a * b for a, b in zip(v1, v2, strict=True))
         magnitude1 = math.sqrt(sum(a * a for a in v1))
         magnitude2 = math.sqrt(sum(b * b for b in v2))
 

--- a/api/middleware.py
+++ b/api/middleware.py
@@ -153,7 +153,7 @@ class ContentTypeValidationMiddleware(BaseHTTPMiddleware):
         if len(actual_parts) != len(pattern_parts):
             return False
 
-        for actual, pattern_part in zip(actual_parts, pattern_parts):
+        for actual, pattern_part in zip(actual_parts, pattern_parts, strict=True):
             # Pattern segments in {} are wildcards
             if pattern_part.startswith("{") and pattern_part.endswith("}"):
                 continue

--- a/api/services.py
+++ b/api/services.py
@@ -233,7 +233,7 @@ async def enrich_sessions_for_listing(
 
     enriched: list[SessionSchema] = [
         normalize_session(session, analysis_summary(analysis))
-        for session, (_, _, analysis, _) in zip(capped_sessions, analyses)
+        for session, (_, _, analysis, _) in zip(capped_sessions, analyses, strict=True)
     ]
 
     for session in sessions[SESSION_ANALYSIS_CAP:]:

--- a/api/trace_routes.py
+++ b/api/trace_routes.py
@@ -63,7 +63,7 @@ async def _load_agent_sessions_with_events(
 
     # Parallelize event loading with asyncio.gather
     events_results = await asyncio.gather(*[repo.get_events(s.id) for s in agent_sessions])
-    events_by_session = {s.id: events for s, (events, _) in zip(agent_sessions, events_results)}
+    events_by_session = {s.id: events for s, (events, _) in zip(agent_sessions, events_results, strict=True)}
 
     return agent_sessions, events_by_session
 

--- a/collector/clustering/cross_session.py
+++ b/collector/clustering/cross_session.py
@@ -178,7 +178,7 @@ class CrossSessionClusterAnalyzer:
         total_weight = 0.0
         weighted_sum = 0.0
 
-        for ts, score in zip(timestamps, scores):
+        for ts, score in zip(timestamps, scores, strict=True):
             # Calculate age in days
             age_days = (now - _to_aware_utc(ts)).total_seconds() / 86400.0
 

--- a/collector/policy_analysis.py
+++ b/collector/policy_analysis.py
@@ -238,7 +238,7 @@ def _compute_string_magnitude(old_val: str, new_val: str) -> float:
         return 0.0
 
     # Simple character-level comparison
-    matches = sum(1 for a, b in zip(old_val, new_val) if a == b)
+    matches = sum(1 for a, b in zip(old_val, new_val, strict=False) if a == b)
 
     # Similarity ratio
     similarity = matches / max_len if max_len > 0 else 1.0

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -852,7 +852,7 @@ class TestBenchmarkRankingAssertions:
             checkpoint_event_ids = {cp.event_id for cp in session.checkpoints}
 
             rankings = []
-            for event, fp in zip(session.events, fingerprints):
+            for event, fp in zip(session.events, fingerprints, strict=True):
                 ranking = compute_event_ranking(
                     event,
                     fp,
@@ -909,7 +909,7 @@ class TestBenchmarkRankingAssertions:
             checkpoint_event_ids = {cp.event_id for cp in session.checkpoints}
 
             rankings = []
-            for event, fp in zip(session.events, fingerprints):
+            for event, fp in zip(session.events, fingerprints, strict=True):
                 ranking = compute_event_ranking(
                     event,
                     fp,


### PR DESCRIPTION
## Summary

Adds explicit `strict=` to all 8 `zip()` call sites flagged by ruff **B905** (`zip()` without an explicit `strict=` parameter), making each parallel-iteration invariant self-documenting. Behavior-preserving.

The repo's lint config is `E/F/I` only, so `B905` only surfaces via explicit `--select B905` — this clears that surface the same way prior modernization PRs (#272–#281) cleared UP/SIM/B/RUF/C4/PIE.

## Changes

**`strict=True`** — 7 sites where the two iterables are provably same-length:

| File | Site | Same-length guarantee |
|------|------|----------------------|
| `agent_debugger_sdk/core/violation_detector.py:140` | cosine-sim dot product | vectors pre-truncated to `min_len` two lines above |
| `api/middleware.py:155` | path-segment compare | early `return False` on `len(actual_parts) != len(pattern_parts)` |
| `api/services.py:236` | session↔analysis enrich | `analyses = asyncio.gather(*[… for s in capped_sessions])` → 1:1 by construction |
| `api/trace_routes.py:66` | session↔events map | `events_results = asyncio.gather(*[… for s in agent_sessions])` → 1:1 |
| `collector/clustering/cross_session.py:181` | timestamps↔scores decay | appended together in the same loop iteration (`data["scores"].append(score)` + `data["timestamps"].append(...)`) |
| `tests/test_benchmarks.py:855` | event↔fingerprint ranking | `fingerprints` built 1:1 from `session.events` in the loop directly above |
| `tests/test_benchmarks.py:912` | event↔fingerprint clustering | same 1:1 construction |

`strict=True` documents the invariant and turns any future invariant break into a loud `ValueError` instead of a silent misaligned zip.

**`strict=False`** — 1 site where truncation is the intended behavior:

| File | Site | Why truncation is correct |
|------|------|---------------------------|
| `collector/policy_analysis.py:241` | char-level string diff | `max_len = max(len(old_val), len(new_val))`; zip intentionally matches over the shorter string, then divides `matches / max_len` to produce a difference ratio. `strict=False` documents that mismatched lengths are expected. |

## Validation

- `ruff check . --select B905` → **All checks passed!** (8 → 0)
- `ruff check .` (full E/F/I) → clean
- `python3 -m pytest -q` → **2968 passed, 19 skipped** (unchanged from main baseline)

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
