### PR TITLE
test: fix vacuous assertion and late-binding closures (SIM222/B023)

### DIFF
--- a/agent_debugger_sdk/adapters/tests/test_bug_fixes.py
+++ b/agent_debugger_sdk/adapters/tests/test_bug_fixes.py
@@ -276,7 +276,7 @@ class TestBUG012ExceptionInfo:
             assert error_event.error_message == "Tool failed"
             # Check that stack_trace is populated (should contain traceback info)
             assert error_event.stack_trace is not None
-            assert "failing_tool_func" in error_event.stack_trace or "Stack trace should contain the function name"
+            assert "failing_tool_func" in error_event.stack_trace, "Stack trace should contain the function name"
 
     @pytest.mark.asyncio
     async def test_trace_llm_exception_passed(self):

--- a/tests/test_violation_routes.py
+++ b/tests/test_violation_routes.py
@@ -274,7 +274,7 @@ def test_search_violations_various_queries(api_repo_factory):
     ]
 
     for query in test_queries:
-        async def run():
+        async def run(query=query):
             async with api_repo_factory() as session:
                 repo = TraceRepository(session)
                 return await search_endpoint(
@@ -559,7 +559,7 @@ def test_get_violation_dashboard_different_time_ranges(api_repo_factory):
     time_ranges = [1, 7, 30, 90]
 
     for days in time_ranges:
-        async def run():
+        async def run(days=days):
             async with api_repo_factory() as session:
                 repo = TraceRepository(session)
                 return await dashboard_endpoint(


### PR DESCRIPTION
## Summary

Three latent test-correctness defects surfaced by `ruff --select SIM222,B023`. All test-only, behavior-preserving, individually verifiable.

## Changes

**`agent_debugger_sdk/adapters/tests/test_bug_fixes.py:279` — vacuous assertion (SIM222)**

```python
# before — the trailing string is always truthy, so this passed regardless
assert "failing_tool_func" in error_event.stack_trace or "Stack trace should contain the function name"
# after — genuine check with the pytest assert-with-message pattern used throughout this file
assert "failing_tool_func" in error_event.stack_trace, "Stack trace should contain the function name"
```

The test now actually validates that the function name appears in the captured stack trace (it does — verified the test still passes after the fix).

**`tests/test_violation_routes.py:281,566` — closures capturing loop variables (B023)**

Two `async def run()` defined inside `for` loops referenced the loop variables `query` / `days`. These are safe **today** because each `run()` is driven to completion via `asyncio.run()` within the same iteration (and the dashboard test even asserts `data["time_range_days"] == days` afterward). But any future refactor that deferred invocation would hit the classic Python late-binding bug. Bound the loop vars via default arguments — the canonical defensive idiom:

```python
for query in test_queries:
    async def run(query=query):   # was: async def run():
```

## Validation

- `ruff check --select SIM222,B023 .` → 0 (was 3)
- `ruff check` (default E/F/I) on both files → clean
- `pytest agent_debugger_sdk/adapters/tests/test_bug_fixes.py tests/test_violation_routes.py` → 47 passed, 1 skipped (unrelated `pydantic_ai not installed`)

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
