### PR TITLE
chore: prefer iterable unpacking over concat (RUF005)

### DIFF
--- a/redaction/pipeline.py
+++ b/redaction/pipeline.py
@@ -251,10 +251,10 @@ class RedactionPipeline:
 
         if isinstance(obj, dict):
             for key, value in obj.items():
-                candidates.extend(self._collect_string_candidates(value, path + (key,), priority_only=priority_only))
+                candidates.extend(self._collect_string_candidates(value, (*path, key), priority_only=priority_only))
         elif isinstance(obj, list):
             for index, value in enumerate(obj):
-                candidates.extend(self._collect_string_candidates(value, path + (index,), priority_only=priority_only))
+                candidates.extend(self._collect_string_candidates(value, (*path, index), priority_only=priority_only))
 
         candidates.sort(key=lambda item: len(item[1].encode("utf-8")), reverse=True)
         return candidates

--- a/tests/test_causal_analysis.py
+++ b/tests/test_causal_analysis.py
@@ -574,7 +574,7 @@ class TestRankFailureCandidates:
         causes = [_event(f"cause{i}", EventType.DECISION) for i in range(5)]
         failure = _event("fail", EventType.ERROR, parent_id="cause0")
 
-        events = causes + [failure]
+        events = [*causes, failure]
         id_lookup = {e.id: e for e in events}
         index_lookup = {e.id: i for i, e in enumerate(events)}
 


### PR DESCRIPTION
## Summary

Clears the last `RUF005` (collection-literal-concatenation) violations by replacing tuple/list concatenation with iterable unpacking. Behavior-identical — each rewrite produces the same tuple/list value.

## Changes

- `redaction/pipeline.py` (2 sites): `path + (key,)` / `path + (index,)` → `(*path, key)` / `(*path, index)` in `_collect_string_candidates` recursive calls.
- `tests/test_causal_analysis.py` (1 site): `causes + [failure]` → `[*causes, failure]` in the rank-failure-candidates test.

## Why

`RUF005` is a pyupgrade-family modernization in the same class as the `UP024`/`UP035`/`UP007` batches already merged. These 3 were the only remaining sites; they surface only under explicit `--select RUF005` since the repo lint config is `E/F/I` only.

## Validation

- `ruff check .` clean (and `--select RUF005` → All checks passed).
- Targeted suite green: `tests/test_causal_analysis.py` + the three `tests/test_redaction*.py` files — 75 passed.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
