### PR TITLE
test: use raw strings for pytest.raises match patterns (RUF043)

### DIFF
--- a/tests/test_reasoning_editor.py
+++ b/tests/test_reasoning_editor.py
@@ -365,7 +365,7 @@ class TestReasoningEditor:
 
     def test_edit_nonexistent_event_raises_error(self, reasoning_editor):
         """Test that editing non-existent event raises error."""
-        with pytest.raises(ValueError, match="Event .* not found"):
+        with pytest.raises(ValueError, match=r"Event .* not found"):
             reasoning_editor.edit_reasoning(
                 event_id="nonexistent",
                 operation=EditOperation.MODIFY,
@@ -375,12 +375,12 @@ class TestReasoningEditor:
 
     def test_get_events_for_replay_nonexistent_event_raises_error(self, reasoning_editor):
         """Test that getting events for replay with nonexistent event raises error."""
-        with pytest.raises(ValueError, match="Event .* not found"):
+        with pytest.raises(ValueError, match=r"Event .* not found"):
             reasoning_editor.get_events_for_replay("nonexistent")
 
     def test_export_nonexistent_scenario_raises_error(self, reasoning_editor):
         """Test that exporting non-existent scenario raises error."""
-        with pytest.raises(ValueError, match="Branch .* not found"):
+        with pytest.raises(ValueError, match=r"Branch .* not found"):
             reasoning_editor.export_scenario("nonexistent")
 
 


### PR DESCRIPTION
## Summary

Clears the 3 `RUF043` (pytest-raises-ambiguous-pattern) violations in `tests/test_reasoning_editor.py` by converting the `pytest.raises(..., match="...")` patterns to raw strings.

The patterns (`"Event .* not found"`, `"Branch .* not found"`) contain regex metacharacters (`.*`) but were written as plain strings, making the regex intent ambiguous. Prefixing with `r""` documents that the metacharacters are intentional.

## Why this is safe

- The patterns contain **no backslash sequences**, so `"...""` and `r"..."` are **byte-identical** — the matched regex is unchanged.
- Verified against source: `reasoning_editor.py` raises `ValueError(f"Event {event_id} not found")` and `ValueError(f"Branch {branch_id} not found")`, which both match the (unchanged) patterns.
- `ruff check .` clean; `pytest tests/test_reasoning_editor.py` → 24 passed.

## Changes
- `tests/test_reasoning_editor.py`: 3 `match="..."` → `match=r"..."` (lines 368, 378, 383).

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
