### PR TITLE
chore: collapse redundant if-branches and dict loops (SIM114/PERF403/PERF102)

### DIFF
--- a/agent_debugger_sdk/core/exporters/pipeline.py
+++ b/agent_debugger_sdk/core/exporters/pipeline.py
@@ -63,9 +63,7 @@ class MemoryExporterHook:
 
         # Check if we should export based on session status
         should_export = False
-        if self.export_on_completion and str(session.status) == "completed":
-            should_export = True
-        elif self.export_on_update:
+        if (self.export_on_completion and str(session.status) == "completed") or self.export_on_update:
             should_export = True
 
         if not should_export:

--- a/api/search_routes.py
+++ b/api/search_routes.py
@@ -148,9 +148,9 @@ async def search_sessions_nl(
         search_query = interpreted.pop("query", search_query)
 
         # Apply interpreted filters unless explicitly overridden
-        for key, value in interpreted.items():
-            if key not in {"query"} and value is not None:
-                filters_applied[key] = value
+        filters_applied.update(
+            {key: value for key, value in interpreted.items() if key not in {"query"} and value is not None}
+        )
 
     # Apply explicit filters from request (override interpreted ones)
     if request.status is not None:

--- a/api/services.py
+++ b/api/services.py
@@ -734,9 +734,7 @@ def extract_workflow_graph(events: list[TraceEvent], session_id: str) -> dict[st
 
         # Determine node status
         status = "pending"
-        if event.event_type == EventType.ERROR:
-            status = "failure"
-        elif getattr(event, "error", None):
+        if event.event_type == EventType.ERROR or getattr(event, "error", None):
             status = "failure"
         elif event.event_type in (EventType.TOOL_CALL, EventType.LLM_REQUEST):
             # Check if there's a corresponding result

--- a/collector/intelligence/compute.py
+++ b/collector/intelligence/compute.py
@@ -243,11 +243,8 @@ def compute_retry_churn_score(events: list[TraceEvent]) -> float:
         if not current_tool or not next_tool:
             continue
 
-        # Same tool called consecutively
-        if current_tool == next_tool:
-            retry_count += 1
-        # Similar tool names (e.g., search_file, search_files)
-        elif _tools_are_similar(current_tool, next_tool):
+        # Same tool called consecutively, or similar tool names (e.g., search_file, search_files)
+        if current_tool == next_tool or _tools_are_similar(current_tool, next_tool):
             retry_count += 1
 
     # Score based on retry density in the window

--- a/tests/intelligence/test_clustering.py
+++ b/tests/intelligence/test_clustering.py
@@ -89,7 +89,7 @@ class TestCrossSessionClustering:
                     }
                 )
         assert len(all_failure_fingerprints) > 0, "Should have at least one failure cluster"
-        for _, cluster_data_list in all_failure_fingerprints.items():
+        for cluster_data_list in all_failure_fingerprints.values():
             for cluster_data in cluster_data_list:
                 cluster = cluster_data["cluster"]
                 assert "count" in cluster


### PR DESCRIPTION
## Summary

Behavior-preserving ruff simplifications — the last small safe opt-in batch after 26 prior cleanup iterations drove the maintainer's E/F/I lint config surface to zero. Surfaces only under explicit `--select SIM114,PERF403,PERF102` (the repo config is E/F/I only).

## Changes (5 sites, 5 files)

**SIM114 — combine adjacent `if`/`elif` branches with identical bodies via `or`:**
- `agent_debugger_sdk/core/exporters/pipeline.py` — export gate (`export_on_completion and status=="completed"` OR `export_on_update`)
- `api/services.py` — graph node-status failure check (`event_type == ERROR` OR `getattr(event, "error", None)`)
- `collector/intelligence/compute.py` — retry-count increment for same-tool OR similar-tool (comments preserved)

**PERF403 — manual dict loop → dict comprehension:**
- `api/search_routes.py` — interpreted-filter application

**PERF102 — iterate `.values()` instead of `.items()` with unused key:**
- `tests/intelligence/test_clustering.py`

## Excluded

The 3 `UP037` (quoted-annotation) hits in `collector/replay_collapse.py` are **false positives**: `TraceEvent` is imported under `if TYPE_CHECKING:`, so unquoting risks a `get_type_hints()` `NameError`. Same false-positive class as the prior UP037 batch — deliberately left quoted.

## Validation

- `ruff check . --select SIM114,PERF403,PERF102,UP037` → only the 3 excluded UP037 remain
- `ruff check .` (E/F/I) → All checks passed
- Targeted pytest (search_routes, memory_exporters, clustering, churn_detection, collector_baseline): **95 passed**
- Full baseline before edits: 2968 passed, 19 skipped, 0 warnings

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
