### PR TITLE
fix(swimlane): repair TypeError crash on None event timestamp sort

### DIFF
--- a/agent_debugger_sdk/core/swimlane.py
+++ b/agent_debugger_sdk/core/swimlane.py
@@ -750,8 +750,10 @@ def analyze_multi_agent_session(events: list[TraceEvent]) -> MultiAgentSession:
     session_id = events[0].session_id if events else ""
     multi_session = MultiAgentSession(session_id=session_id)
 
-    # Sort events by timestamp
-    sorted_events = sorted(events, key=lambda e: e.timestamp or datetime.min(timezone.utc))
+    # Sort events by timestamp. datetime.min is a constant, not callable, so the
+    # fallback must use .replace(tzinfo=...) to yield a tz-aware sentinel that
+    # sorts correctly alongside tz-aware event timestamps without crashing.
+    sorted_events = sorted(events, key=lambda e: e.timestamp or datetime.min.replace(tzinfo=timezone.utc))
 
     # Add events to appropriate lanes
     for event in sorted_events:

--- a/tests/test_swimlane.py
+++ b/tests/test_swimlane.py
@@ -198,6 +198,38 @@ def test_analyze_multi_agent_session(sample_multi_agent_events):
     assert session.get_duration_seconds() > 0
 
 
+def test_analyze_multi_agent_session_handles_none_timestamp():
+    """Regression: a None timestamp must not crash the sort key.
+
+    The previous fallback ``datetime.min(timezone.utc)`` treated the
+    ``datetime.min`` constant as callable and raised
+    ``TypeError: 'datetime.datetime' object is not callable`` whenever any
+    event had a falsy timestamp. The tz-aware ``.replace(tzinfo=...)``
+    sentinel sorts such events to the front without crashing.
+    """
+    early = TraceEvent(
+        id="event_none_ts",
+        session_id="session_none_ts",
+        timestamp=None,  # pyright: ignore[reportArgumentType]  # exercises the None-fallback at runtime
+        event_type=EventType.AGENT_TURN,
+        data={"agent_id": "agent_none"},
+    )
+    later = TraceEvent(
+        id="event_real_ts",
+        session_id="session_none_ts",
+        timestamp=datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        event_type=EventType.AGENT_TURN,
+        data={"agent_id": "agent_real"},
+    )
+
+    # Must not raise; previously TypeError on the sort key.
+    session = analyze_multi_agent_session([later, early])
+
+    assert session.get_total_event_count() == 2
+    # Both events carry an agent_id, so each lands in its own lane.
+    assert session.get_agent_count() == 2
+
+
 def test_get_swimlane_data(sample_multi_agent_events):
     """Test getting swimlane visualization data."""
     data = get_swimlane_data("test_session_1", sample_multi_agent_events)


### PR DESCRIPTION
## Summary

Fixes a latent `TypeError` crash in `analyze_multi_agent_session` (multi-agent swimlane analysis) when any event has a `None` timestamp.

## Root cause

`agent_debugger_sdk/core/swimlane.py:754` sorted events with the key:

```python
sorted_events = sorted(events, key=lambda e: e.timestamp or datetime.min(timezone.utc))
```

`datetime.min` is a constant **instance**, not callable. The `or` fallback only triggers when `e.timestamp` is falsy (`None`), so whenever a None-timestamp event reached this sort, Python raised:

```
TypeError: 'datetime.datetime' object is not callable
```

The defensive fallback existed precisely to handle None timestamps — but the fallback itself crashed instead of providing a sentinel.

None timestamps are reachable at runtime: `TraceEvent` is typed `timestamp: datetime`, but deserialization (`events/base.py` `from_dict`) does not guard a `None` value in the payload, so a malformed/deserialized event can carry `timestamp=None`.

## Fix

```python
sorted_events = sorted(events, key=lambda e: e.timestamp or datetime.min.replace(tzinfo=timezone.utc))
```

`datetime.min.replace(tzinfo=timezone.utc)` is a real callable yielding a **tz-aware** minimum, so None-timestamp events:
1. No longer crash the sort (`.replace` is callable, `datetime.min(...)` was not).
2. Sort to the front as the earliest possible time.
3. Don't mix naive/aware datetimes with the tz-aware real event timestamps — the same defect class fixed for `cross_session.py` in #278.

## Reproduction

```python
from agent_debugger_sdk.core.swimlane import analyze_multi_agent_session
from agent_debugger_sdk.core.events.base import TraceEvent
from agent_debugger_sdk.core.events import EventType
e = TraceEvent(event_type=EventType.AGENT_TURN, session_id="s1", timestamp=None)
analyze_multi_agent_session([e])  # before: TypeError; after: ok
```

## Test coverage

Added `test_analyze_multi_agent_session_handles_none_timestamp` regression test mixing a `None`-timestamp event with a tz-aware one; asserts no crash, both events counted, both land in lanes.

## Validation

- `ruff check .` — clean (E/F/I)
- `pytest -q` — 2969 passed, 19 skipped (was 2968 + 1 new test), 0 warnings
- Reproduced the crash on `origin/main` before the fix; confirmed resolved after

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
