### PR TITLE
fix(tests): use UTC datetime in analytics_db aggregate fixtures (DTZ005)

### DIFF
--- a/tests/test_analytics_db.py
+++ b/tests/test_analytics_db.py
@@ -255,8 +255,8 @@ class TestGetAggregates:
         """Test that get_aggregates sums data across multiple days."""
         analytics_db.init_analytics_db()
 
-        today = datetime.now().strftime("%Y-%m-%d")
-        yesterday = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%d")
 
         conn = sqlite3.connect(str(mock_db_path))
         conn.execute(
@@ -279,8 +279,8 @@ class TestGetAggregates:
         """Test that get_aggregates only includes data within the specified range."""
         analytics_db.init_analytics_db()
 
-        today = datetime.now().strftime("%Y-%m-%d")
-        old_date = (datetime.now() - timedelta(days=10)).strftime("%Y-%m-%d")
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        old_date = (datetime.now(timezone.utc) - timedelta(days=10)).strftime("%Y-%m-%d")
 
         conn = sqlite3.connect(str(mock_db_path))
         conn.execute(


### PR DESCRIPTION
## Summary

Fixes a timezone-mismatch latent defect in the `test_analytics_db.py` aggregate fixtures, found via a `ruff --select DTZ005` scan.

## Problem

The analytics repository computes its date windows in **UTC**:
- `storage/repositories/analytics_repo.py` `get_aggregates:162` — `cutoff_date = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%d")`
- `get_daily_breakdown:228` — `today = datetime.now(timezone.utc)`

Four fixture sites in `TestGetAggregates` had drifted to **naive local** `datetime.now()`:
- `test_get_aggregates_sums_multiple_days` — `today` / `yesterday`
- `test_get_aggregates_respects_days_parameter` — `today` / `old_date`

So the seeded `today` / `yesterday` / `old_date` strings were LOCAL dates compared against a UTC query window — timezone-dependent and wrong on any non-UTC host. The same file already uses UTC at lines 156/198, confirming the intended baseline.

## Fix

Align the four sites to `datetime.now(timezone.utc)` to match the repository's UTC windowing. `timezone` was already imported.

```diff
-        today = datetime.now().strftime("%Y-%m-%d")
-        yesterday = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%d")
```

## Validation

- `ruff check .` clean (E/F/I), `DTZ005` clear on the file
- `pytest tests/test_analytics_db.py` — 26 passed
- Diff is 4 lines, test-only; identical output on UTC hosts, correct output on non-UTC hosts

## Out of scope

The 4 remaining `DTZ005` sites (`exporters/__init__.py:78`, `exporters/file.py:342/379`, `api/services.py:835`) are serialized metadata with no consumers that parse them — a separate consistency/serialization judgment, not a mismatch bug, so left for a dedicated iteration.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
