### PR TITLE
chore(deps): bump starlette 1.0.0 -> 1.3.1 (security)

### DIFF
--- a/pyproject-server.toml
+++ b/pyproject-server.toml
@@ -28,6 +28,7 @@ classifiers = [
 dependencies = [
     "peaky-peek>=0.1.0",
     "fastapi>=0.100",
+    "starlette>=1.3.1",  # security floor: 1.3.1 fixes PYSEC-2026-161/-248/-249, CVE-2026-48817/-48818
     "uvicorn[standard]>=0.20",
     "sqlalchemy[asyncio]>=2.0",
     "aiosqlite>=0.19",

--- a/uv.lock
+++ b/uv.lock
@@ -4609,15 +4609,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps starlette `1.0.0` → `1.3.1` to clear 5 known CVEs. `uv.lock` pinned the vulnerable `1.0.0` (transitive via `fastapi`), so `uv sync` / `make install` installed it even though a fresh resolve picks the patched `1.3.1`.

## CVEs fixed

| ID | Fixed in |
|----|----------|
| PYSEC-2026-161 | 1.0.1 |
| PYSEC-2026-248 | 1.3.0 |
| PYSEC-2026-249 | 1.3.1 |
| CVE-2026-48817 | 1.1.0 |
| CVE-2026-48818 | 1.1.0 |

## Changes

- `pyproject-server.toml`: add `starlette>=1.3.1` security floor (starlette is server-side via fastapi; SDK package untouched).
- `uv.lock`: update the starlette `[[package]]` block to 1.3.1 (version + sdist/wheel hashes). This is uv's own generated block for 1.3.1, transplanted surgically so the rest of the lockfile is untouched.

## Compatibility

- `fastapi 0.135.2` requires `starlette>=0.46.0` (no upper bound) → 1.3.1 fully compatible.
- starlette `1.0.0` and `1.3.1` have identical core deps (`anyio` + `typing-extensions`, py<3.13 marker), so no other lock entries shift.
- Single first-party direct import (`from starlette.middleware.base import BaseHTTPMiddleware`) is stable across 1.x.

## Validation

- `pip install --dry-run starlette==1.3.1`: clean, no conflicts.
- Full pytest with starlette 1.3.1 installed: **2969 passed / 19 skipped** (matches baseline).
- `ruff check .`: clean.
- `pyproject-server.toml` server-deps pip-audit target: clean (1.3.1 has no known vulns).

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
