### PR TITLE
ci: schedule the dependency-scan workflow to run weekly

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -1,7 +1,10 @@
 name: Dependency scan (scheduled)
 
 on:
-  workflow_dispatch:      # manual trigger only
+  schedule:
+    # Weekly: Mondays 06:17 UTC (off the top of the hour to spread GitHub Actions load)
+    - cron: "17 6 * * 1"
+  workflow_dispatch:      # manual trigger
 
 permissions:
   contents: read


### PR DESCRIPTION
## What

The `dependency-scan` workflow is named **Dependency scan (scheduled)** but its only trigger was `workflow_dispatch` (manual). It has **never run** in CI (zero run history), so it gated nothing.

This is precisely why the starlette 1.0.0 CVEs fixed in #291 stayed latent: the `full-audit` job (which runs `pip-audit --desc --strict` over the full transitive tree) would have caught them, but it was never scheduled — only the repo's own CI pip-audit (which audits direct pyproject deps only, where starlette is transitive via fastapi) ran, and it was clean.

## Change

Add a weekly `schedule` trigger (Mondays 06:17 UTC) alongside `workflow_dispatch`, so the two jobs run automatically:

- **GuardDog supply-chain scan** — scans SDK + server direct deps for malicious-package indicators
- **Full pip-audit** — audits the entire transitive dependency tree for known CVEs

The 06:17 UTC minute is intentionally off the top of the hour to spread GitHub Actions runner load.

## Validation

- YAML parses cleanly; triggers now `['schedule', 'workflow_dispatch']`.
- Confirmed the `full-audit` job **passes today** (no remaining CVEs after the #291 starlette bump): replicated the exact CI install (`fastapi uvicorn[standard] sqlalchemy[asyncio] aiosqlite alembic aiofiles bcrypt httpx` + pip-audit) in a clean venv → `No known vulnerabilities found`, exit 0.
- Audited all other workflows for the same name/trigger mismatch; `dependency-scan.yml` was the only one (ci/pages/publish/secret-scan all have appropriate triggers).
- Not a required status check, so a future finding will surface as a failed run / notification rather than blocking merges.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>